### PR TITLE
Download as temp file and rename later

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,7 +36,6 @@ android {
 }
 
 dependencies {
-
     implementation 'androidx.core:core-ktx:1.9.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.11.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id 'com.android.application' version '8.1.4' apply false
-    id 'org.jetbrains.kotlin.android' version '1.9.0' apply false
+    id 'org.jetbrains.kotlin.android' version '2.0.0' apply false
     id 'com.android.library' version '8.1.4' apply false
-    id 'com.google.devtools.ksp' version '1.9.0-1.0.13' apply false
+    id 'com.google.devtools.ksp' version '2.0.0-1.0.23' apply false
+    id 'org.jetbrains.kotlin.plugin.serialization' version '2.0.0'
 }

--- a/ketch/build.gradle
+++ b/ketch/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
     id 'com.google.devtools.ksp'
+    id 'org.jetbrains.kotlin.plugin.serialization'
 }
 
 android {
@@ -31,19 +32,17 @@ android {
 }
 
 dependencies {
-
-    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.11.0'
+    implementation 'androidx.core:core-ktx:1.13.1'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 
     implementation "androidx.work:work-runtime-ktx:2.9.0"
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
-    implementation 'com.google.code.gson:gson:2.10.1'
 
-    implementation("androidx.room:room-runtime:2.5.2")
-    ksp("androidx.room:room-compiler:2.5.2")
-    implementation("androidx.room:room-ktx:2.5.2")
+    implementation("androidx.room:room-runtime:2.6.1")
+    ksp("androidx.room:room-compiler:2.6.1")
+    implementation("androidx.room:room-ktx:2.6.1")
+
+    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.1'
 }

--- a/ketch/src/main/java/com/ketch/DownloadConfig.kt
+++ b/ketch/src/main/java/com/ketch/DownloadConfig.kt
@@ -1,7 +1,9 @@
 package com.ketch
 
 import com.ketch.internal.utils.DownloadConst
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class DownloadConfig(
     val connectTimeOutInMs: Long = DownloadConst.DEFAULT_VALUE_CONNECT_TIMEOUT_MS,
     val readTimeOutInMs: Long = DownloadConst.DEFAULT_VALUE_READ_TIMEOUT_MS

--- a/ketch/src/main/java/com/ketch/NotificationConfig.kt
+++ b/ketch/src/main/java/com/ketch/NotificationConfig.kt
@@ -1,7 +1,9 @@
 package com.ketch
 
 import com.ketch.internal.utils.NotificationConst
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class NotificationConfig(
     val enabled: Boolean = NotificationConst.DEFAULT_VALUE_NOTIFICATION_ENABLED,
     val channelName: String = NotificationConst.DEFAULT_VALUE_NOTIFICATION_CHANNEL_NAME,

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadRequest.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadRequest.kt
@@ -1,7 +1,9 @@
 package com.ketch.internal.download
 
 import com.ketch.internal.utils.FileUtil.getUniqueId
+import kotlinx.serialization.Serializable
 
+@Serializable
 internal data class DownloadRequest(
     val url: String,
     val path: String,

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadTask.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadTask.kt
@@ -21,9 +21,10 @@ internal class DownloadTask(
 
         var rangeStart = 0L
         val file = File(path, fileName)
+        val tmp = File(file.path+".tmp")
 
-        if (file.exists()) {
-            rangeStart = file.length()
+        if (tmp.exists()) {
+            rangeStart = tmp.length()
         }
 
         if (rangeStart != 0L) {
@@ -57,10 +58,8 @@ internal class DownloadTask(
 
         totalBytes += rangeStart
 
-        val out = FileOutputStream(file, true)
-
         responseBody.byteStream().use { inputStream ->
-            out.use { outputStream ->
+            FileOutputStream(tmp, true).use { outputStream ->
 
                 if (rangeStart != 0L) {
                     progressBytes = rangeStart
@@ -97,7 +96,7 @@ internal class DownloadTask(
                 onProgress.invoke(totalBytes, totalBytes, 0F)
             }
         }
-
+        require(tmp.renameTo(file)) { "Failed to rename temp file to destination file" }
         return totalBytes
     }
 

--- a/ketch/src/main/java/com/ketch/internal/download/ETagChecker.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/ETagChecker.kt
@@ -2,6 +2,10 @@ package com.ketch.internal.download
 
 import com.ketch.internal.network.DownloadService
 import com.ketch.internal.utils.DownloadConst
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.HttpURLConnection
+import java.net.URL
 
 internal class ETagChecker(
     private val url: String,

--- a/ketch/src/main/java/com/ketch/internal/notification/DownloadNotificationManager.kt
+++ b/ketch/src/main/java/com/ketch/internal/notification/DownloadNotificationManager.kt
@@ -158,7 +158,7 @@ internal class DownloadNotificationManager(
             Intent(context, NotificationReceiver::class.java).apply {
                 putExtra(
                     NotificationConst.KEY_NOTIFICATION_CHANNEL_NAME,
-                    notificationConfig.smallIcon
+                    notificationConfig.channelName
                 )
                 putExtra(
                     NotificationConst.KEY_NOTIFICATION_CHANNEL_IMPORTANCE,

--- a/ketch/src/main/java/com/ketch/internal/utils/WorkUtil.kt
+++ b/ketch/src/main/java/com/ketch/internal/utils/WorkUtil.kt
@@ -3,47 +3,44 @@ package com.ketch.internal.utils
 import com.ketch.DownloadConfig
 import com.ketch.NotificationConfig
 import com.ketch.internal.download.DownloadRequest
-import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 
 internal object WorkUtil {
 
     fun DownloadRequest.toJson(): String {
-        return Gson().toJson(this)
+        return Json.encodeToString(this)
     }
 
     fun jsonToDownloadRequest(jsonStr: String): DownloadRequest {
-        return Gson().fromJson(jsonStr, DownloadRequest::class.java)
+        return Json.decodeFromString(jsonStr)
     }
 
     fun DownloadConfig.toJson(): String {
-        return Gson().toJson(this)
+        return Json.encodeToString(this)
     }
 
     fun jsonToDownloadConfig(jsonStr: String): DownloadConfig {
         if (jsonStr.isEmpty()) return DownloadConfig()
-        return Gson().fromJson(jsonStr, DownloadConfig::class.java)
+        return Json.decodeFromString(jsonStr)
     }
 
     fun NotificationConfig.toJson(): String {
-        return Gson().toJson(this)
+        return Json.encodeToString(this)
     }
 
     fun jsonToNotificationConfig(jsonStr: String): NotificationConfig {
         if (jsonStr.isEmpty()) return NotificationConfig(smallIcon = NotificationConst.DEFAULT_VALUE_NOTIFICATION_SMALL_ICON)
-        return Gson().fromJson(jsonStr, NotificationConfig::class.java)
+        return Json.decodeFromString(jsonStr)
     }
 
     fun hashMapToJson(headers: HashMap<String, String>): String {
         if (headers.isEmpty()) return ""
-        val gson = Gson()
-        return gson.toJson(headers)
+        return Json.encodeToString(headers)
     }
 
     fun jsonToHashMap(jsonString: String): HashMap<String, String> {
         if (jsonString.isEmpty()) return hashMapOf()
-        val gson = Gson()
-        val type = object : TypeToken<HashMap<String, String>>() {}.type
-        return gson.fromJson(jsonString, type)
+        return Json.decodeFromString(jsonString)
     }
 }


### PR DESCRIPTION
Write to a temporary file during download and rename it to the destination file upon completion.

- This avoids the need to check if the file exists before starting the download.