### PR TITLE
fix/getFileNameFromUrl

### DIFF
--- a/.kotlin/errors/errors-1736761423599.log
+++ b/.kotlin/errors/errors-1736761423599.log
@@ -1,0 +1,4 @@
+kotlin version: 2.0.10
+error message: The daemon has terminated unexpectedly on startup attempt #1 with error code: 0. The daemon process output:
+    1. Kotlin compile daemon is ready
+

--- a/app/src/main/java/com/khush/sample/MainFragment.kt
+++ b/app/src/main/java/com/khush/sample/MainFragment.kt
@@ -138,9 +138,8 @@ class MainFragment : Fragment() {
         fragmentMainBinding.bt1.text = "Video 1"
         fragmentMainBinding.bt1.setOnClickListener {
             ketch.download(
-                url = "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+                url = "https://dl.bir-music.com/1403/04/04/Roozbeh%20Bemani%20-%20Video/Roozbeh%20Bemani%20-%20Tarik.mp4",
                 path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path,
-                fileName = "Sample_Video_1.mp4",
                 tag = "Video",
                 metaData = "158"
             )
@@ -149,9 +148,8 @@ class MainFragment : Fragment() {
         fragmentMainBinding.bt2.text = "Video 2"
         fragmentMainBinding.bt2.setOnClickListener {
             ketch.download(
-                url = "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4",
+                url = "https://dl.bir-music.com/1403/07/15/Erfan%20Tahmasbi%20-%20Kojaei%20Video/Erfan%20Tahmasbi%20-%20Kojaei%20%28Live%20In%20Concert%29%20480.mp4",
                 path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path,
-                fileName = "Sample_Video_2.mp4",
                 tag = "Video",
                 metaData = "169"
             )
@@ -160,9 +158,8 @@ class MainFragment : Fragment() {
         fragmentMainBinding.bt3.text = "Video 3"
         fragmentMainBinding.bt3.setOnClickListener {
             ketch.download(
-                url = "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/SubaruOutbackOnStreetAndDirt.mp4",
+                url = "https://dl.bir-music.com/1402/09/08/Erfan%20Tahmasbi%20-%20Video/Erfan%20Tahmasbi%20-%20Matarsak%20%28Guitar%20Version%29%20%28720%29.mp4",
                 path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path,
-                fileName = "Sample_Video_3.mp4",
                 tag = "Video",
                 metaData = "48"
             )
@@ -173,7 +170,6 @@ class MainFragment : Fragment() {
             ketch.download(
                 url = "https://picsum.photos/200/300",
                 path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path,
-                fileName = "Sample_Image_1.jpg",
                 tag = "Document",
                 metaData = "1"
             )
@@ -184,7 +180,6 @@ class MainFragment : Fragment() {
             ketch.download(
                 url = "https://sample-videos.com/pdf/Sample-pdf-5mb.pdf",
                 path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path,
-                fileName = "Sample_Pdf_1.pdf",
                 tag = "Document",
                 metaData = "5"
             )
@@ -195,42 +190,36 @@ class MainFragment : Fragment() {
             ketch.download(
                 url = "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
                 path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path,
-                fileName = "Sample_Video_1.mp4",
                 tag = "Video",
                 metaData = "158"
             )
             ketch.download(
                 url = "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4",
                 path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path,
-                fileName = "Sample_Video_2.mp4",
                 tag = "Video",
                 metaData = "169"
             )
             ketch.download(
                 url = "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/SubaruOutbackOnStreetAndDirt.mp4",
                 path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path,
-                fileName = "Sample_Video_3.mp4",
                 tag = "Video",
                 metaData = "48"
             )
             ketch.download(
                 url = "https://sample-videos.com/video321/mp4/720/big_buck_bunny_720p_30mb.mp4",
                 path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path,
-                fileName = "Sample_Video_4.mp4",
                 tag = "Video",
                 metaData = "30"
             )
             ketch.download(
                 url = "https://picsum.photos/200/300",
                 path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path,
-                fileName = "Sample_Image_1.jpg",
                 tag = "Document",
                 metaData = "1"
             )
             ketch.download(
                 url = "https://sample-videos.com/pdf/Sample-pdf-5mb.pdf",
                 path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path,
-                fileName = "Sample_Pdf_1.pdf",
                 tag = "Document",
                 metaData = "5"
             )

--- a/ketch/src/main/java/com/ketch/internal/utils/FileUtil.kt
+++ b/ketch/src/main/java/com/ketch/internal/utils/FileUtil.kt
@@ -1,5 +1,6 @@
 package com.ketch.internal.utils
 
+import android.net.Uri
 import android.os.Environment
 import android.webkit.URLUtil
 import java.io.File
@@ -13,9 +14,38 @@ internal object FileUtil {
         return File(file.absolutePath + ".temp")
     }
 
-    fun getFileNameFromUrl(url: String): String {
+    private fun getFileNameFromUrlUUID(url: String): String {
         val guessFileName = URLUtil.guessFileName(url, null, null)
         return UUID.randomUUID().toString() + "-" + guessFileName
+    }
+    /**
+     * Extracts a file name from a given URL string.
+     *
+     * This function attempts to extract the file name from the last segment of the URL path.
+     * If the URL is invalid, or if a valid file name with an extension cannot be found,
+     * a UUID-based file name is generated using [getFileNameFromUrlUUID]
+     *
+     * @param url The URL string to extract the file name from.
+     * @return The extracted file name, or a UUID-based file name if extraction fails.
+     *
+     * Examples:
+     *  - "https://example.com/path/to/file.txt" -> "file.txt"
+     *  - "https://example.com/image.jpg?query=param" -> "image.jpg"
+     *  - "https://example.com/path/to/file" -> "generated_uuid_string"
+     *  - "invalid_url" -> "generated_uuid_string"
+     */
+    fun getFileNameFromUrl(url: String): String {
+        if (!URLUtil.isValidUrl(url)) {
+            return getFileNameFromUrlUUID(url)
+        }
+        val uri = Uri.parse(url)
+        val fileName = uri.lastPathSegment ?: return getFileNameFromUrlUUID(url)
+        val fileExtension = fileName.substringAfterLast(".", "")
+        return if (fileExtension.isNotEmpty()) {
+            fileName
+        } else {
+            getFileNameFromUrlUUID(url)
+        }
     }
 
     fun getDefaultDownloadPath(): String {


### PR DESCRIPTION
**Refactor** getFileNameFromUrl to handle **invalid URLs** and **missing file extensions** more gracefully. If the URL is **invalid** or the file name is null, a unique name is generated using **UUID.** Additionally, if the file name does not have an extension, a fallback name with **UUID** is returned.