### PR TITLE
Add ability to customize download title, content text, button text

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,11 +155,20 @@ dependencies {
      ketch = Ketch.builder().setNotificationConfig(
               config = NotificationConfig(
                 enabled = true,
-                smallIcon = R.drawable.ic_launcher_foreground // It is required to pass the smallIcon for notification.
+                smallIcon = R.drawable.ic_launcher_foreground, // It is required to pass the smallIcon for notification.
+                smallIcons = NotificationSmallIconConfig(
+                  progress = android.R.drawable.stat_sys_download,
+                  success = android.R.drawable.checkbox_on_background,
+                  failed = android.R.drawable.stat_notify_error,
+                  paused = android.R.drawable.ic_media_pause,
+                  cancelled = android.R.drawable.ic_notification_clear_all
+                ) //Default: smallIcon, pass the smallIcon for notification status
               )
             ).build(this)
      ```
+
      
+    
 ## Customisation
   
 - Provide headers with network request.
@@ -177,6 +186,55 @@ dependencies {
    tag = tag, //Default: null
   )
   ```
+
+- Download title: Customize the title on the notification for the statuses
+
+  ```Kotlin
+  ketch.download(url, fileName, path,
+    downloadTitles = DownloadTitles(
+        progressTitle = "Downloading",
+        failedTitle = "Failed",
+        successTitle = "Success",
+        canceledTitle = "Cancelled",
+        pausedTitle = "Paused"
+    ) //Default: Downloading <file name>
+  )
+  ```
+
+- Download title: Customize the context text on the notification for the statuses
+
+  ```Kotlin
+  ketch.download(url, fileName, path,
+    downloadContentTexts = DownloadContentTexts(
+      successContentText = "Success content",
+      failedContentText = "Failed content",
+      canceledContentText = "Cancelled content ",
+      pausedContentText = "Paused content",
+      progressContentText = DownloadProgressContentText()
+    ), //Default: Default download states, and default progress states in NotificationConfig
+  )
+  ```
+  - Customize download progress status (this will not depend on NotificationConfig)
+  
+    ```Kotlin
+    DownloadProgressContentText(
+      onlySeconds = "Left [[#second|%s second|%s seconds]] - total [[#total|%s|%s]] - speed [[#speed|%s|%s]]",
+      onlyMinutes = "शेष [[#minute|%s मिनट|%s मिनट]]",
+      onlyHours = "Còn lại [[#hour|%s giờ|%s giờ]]",
+      minutesAndSeconds = "Left [[#minute|%s minute|%s minutes]] [[#second|%s second|%s seconds]]",
+      hoursAndMinutes = "Left [[#hour|%s hour|%s hours]] [[#minute|%s minute|%s minutes]]",
+    )
+
+    // Template usage:
+   
+    // #second, #minute, #hour: Time variable
+    // #total: Total download file size variable
+    // #speed: Download speed variable
+    // %s: Plural template (always %s)
+
+    // Syntax: <variable>|%s<text singular time>|%s<plural time text> inside the pair [[ ]]
+    // with #speed and #total just have text in <plural time text>
+    ```
   
 - Download config: Provides custom connect and read timeout
 
@@ -216,6 +274,20 @@ dependencies {
         showTime = true //Default: true
       )
     ).build(this)
+  ```
+
+       
+- Notification config: To customize the text button on the notification       
+     
+  ```Kotlin
+  ketch = Ketch.builder().setButtonTextConfig(
+            ButtonTextConfig(
+                cancel = "Cancel",
+                pause = "Pause",
+                resume = "Resume",
+                retry = "Retry"
+            ) //Default: Default value same as above example
+        ).build(this)
   ```
 
 # Blog

--- a/app/src/main/java/com/khush/sample/MainApplication.kt
+++ b/app/src/main/java/com/khush/sample/MainApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import com.ketch.DownloadConfig
 import com.ketch.Ketch
 import com.ketch.NotificationConfig
+import com.ketch.NotificationSmallIconConfig
 
 class MainApplication : Application() {
 
@@ -16,7 +17,14 @@ class MainApplication : Application() {
             .setNotificationConfig(
                 NotificationConfig(
                     true,
-                    smallIcon = R.drawable.ic_launcher_foreground
+                    smallIcon = R.drawable.ic_launcher_foreground,
+                    smallIcons = NotificationSmallIconConfig(
+                        progress = android.R.drawable.stat_sys_download,
+                        success = android.R.drawable.checkbox_on_background,
+                        failed = android.R.drawable.stat_notify_error,
+                        paused = android.R.drawable.ic_media_pause,
+                        cancelled = android.R.drawable.ic_notification_clear_all
+                    )
                 )
             )
             .enableLogs(true)

--- a/app/src/main/java/com/khush/sample/MainFragment.kt
+++ b/app/src/main/java/com/khush/sample/MainFragment.kt
@@ -135,24 +135,24 @@ class MainFragment : Fragment() {
             )
         )
 
-        fragmentMainBinding.bt1.text = "Video 1"
+        fragmentMainBinding.bt1.text = "kali-linux"
         fragmentMainBinding.bt1.setOnClickListener {
             ketch.download(
-                url = "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+                url = "https://dl3.soft98.ir/linux/debian-12.10.0-i386-DVD-1.iso?1742478582",
                 path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path,
-                fileName = "Sample_Video_1.mp4",
-                tag = "Video",
+                fileName = "kali-linux.iso",
+                tag = "iso",
                 metaData = "158"
             )
         }
 
-        fragmentMainBinding.bt2.text = "Video 2"
+        fragmentMainBinding.bt2.text = "Windows11"
         fragmentMainBinding.bt2.setOnClickListener {
             ketch.download(
-                url = "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4",
+                url = "https://dl3.soft98.ir/win/Windows.11.v24H2.Build.26100.3476.x64-VL.part1.rar?1742478603",
                 path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path,
-                fileName = "Sample_Video_2.mp4",
-                tag = "Video",
+                fileName = "Windows11",
+                tag = "file",
                 metaData = "169"
             )
         }

--- a/app/src/main/java/com/khush/sample/MainFragment.kt
+++ b/app/src/main/java/com/khush/sample/MainFragment.kt
@@ -22,10 +22,14 @@ import androidx.recyclerview.widget.SimpleItemAnimator
 import com.ketch.DownloadModel
 import com.ketch.Ketch
 import com.ketch.Status
+import com.ketch.internal.download.DownloadContentTexts
+import com.ketch.internal.download.DownloadProgressContentText
+import com.ketch.internal.download.DownloadTitles
 import com.khush.sample.databinding.FragmentMainBinding
 import com.khush.sample.databinding.ItemFileBinding
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import java.io.File
 
@@ -142,7 +146,27 @@ class MainFragment : Fragment() {
                 path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path,
                 fileName = "Sample_Video_1.mp4",
                 tag = "Video",
-                metaData = "158"
+                metaData = "158",
+                downloadTitles = DownloadTitles(
+                    progressTitle = "Downloading",
+                    failedTitle = "Failed",
+                    successTitle = "Success",
+                    canceledTitle = "Cancelled",
+                    pausedTitle = "Paused"
+                ),
+                downloadContentTexts = DownloadContentTexts(
+                    successContentText = "Success content",
+                    failedContentText = "Failed content",
+                    canceledContentText = "Cancelled content ",
+                    pausedContentText = "Paused content",
+                    progressContentText = DownloadProgressContentText(
+                        onlySeconds = "Left [[#second|%s second|%s seconds]] - total [[#total|%s|%s]] - speed [[#speed|%s|%s]]",
+                        onlyMinutes = "शेष [[#minute|%s मिनट|%s मिनट]]",
+                        onlyHours = "Còn lại [[#hour|%s giờ|%s giờ]]",
+                        minutesAndSeconds = "Left [[#minute|%s minute|%s minutes]] [[#second|%s second|%s seconds]]",
+                        hoursAndMinutes = "Left [[#hour|%s hour|%s hours]] [[#minute|%s minute|%s minutes]]",
+                    )
+                ),
             )
         }
 

--- a/app/src/main/java/com/khush/sample/MainFragment.kt
+++ b/app/src/main/java/com/khush/sample/MainFragment.kt
@@ -142,7 +142,7 @@ class MainFragment : Fragment() {
         fragmentMainBinding.bt1.text = "Video 1 (with custom title)"
         fragmentMainBinding.bt1.setOnClickListener {
             ketch.download(
-                url = "https://dl3.soft98.ir/linux/debian-12.10.0-i386-DVD-1.iso?1742478582",
+                url = "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
                 path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path,
                 fileName = "Sample_Video_1.mp4",
                 tag = "Video",
@@ -170,13 +170,13 @@ class MainFragment : Fragment() {
             )
         }
 
-        fragmentMainBinding.bt2.text = "Windows11"
+        fragmentMainBinding.bt2.text = "Video 2"
         fragmentMainBinding.bt2.setOnClickListener {
             ketch.download(
-                url = "https://dl3.soft98.ir/win/Windows.11.v24H2.Build.26100.3476.x64-VL.part1.rar?1742478603",
+                url = "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4",
                 path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path,
-                fileName = "Windows11",
-                tag = "file",
+                fileName = "Sample_Video_2.mp4",
+                tag = "Video",
                 metaData = "169"
             )
         }

--- a/app/src/main/java/com/khush/sample/MainFragment.kt
+++ b/app/src/main/java/com/khush/sample/MainFragment.kt
@@ -139,7 +139,7 @@ class MainFragment : Fragment() {
             )
         )
 
-        fragmentMainBinding.bt1.text = "Video 1"
+        fragmentMainBinding.bt1.text = "Video 1 (with custom title)"
         fragmentMainBinding.bt1.setOnClickListener {
             ketch.download(
                 url = "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",

--- a/app/src/main/java/com/khush/sample/Util.kt
+++ b/app/src/main/java/com/khush/sample/Util.kt
@@ -42,7 +42,7 @@ object Util {
 
     private fun getSpeedText(speedInBPerMs: Float): String {
         var value = speedInBPerMs * SEC_IN_MILLIS
-        val units = arrayOf("b/s", "kb/s", "mb/s", "gb/s")
+        val units = arrayOf("B/s", "KB/s", "MB/s", "GB/s")
         var unitIndex = 0
 
         while (value >= VALUE_500 && unitIndex < units.size - 1) {
@@ -55,7 +55,7 @@ object Util {
 
     fun getTotalLengthText(lengthInBytes: Long): String {
         var value = lengthInBytes.toFloat()
-        val units = arrayOf("b", "kb", "mb", "gb")
+        val units = arrayOf("B", "KB", "MB", "GB")
         var unitIndex = 0
 
         while (value >= VALUE_500 && unitIndex < units.size - 1) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,9 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+
+
+
+
+

--- a/ketch/build.gradle
+++ b/ketch/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'com.google.devtools.ksp'
     id 'org.jetbrains.kotlin.plugin.serialization'
+    id 'maven-publish'
 }
 
 android {
@@ -45,3 +46,18 @@ dependencies {
     ksp 'androidx.room:room-compiler:2.6.1'
     implementation 'androidx.room:room-ktx:2.6.1'
 }
+
+afterEvaluate {
+    publishing {
+        publications {
+            create("release", MavenPublication) {
+                groupId = 'com.github.MehdiSekoba'
+                artifactId = 'Ketch'
+                version = '2.0.6'
+            }
+        }
+    }
+}
+
+
+

--- a/ketch/src/main/java/com/ketch/ButtonTextConfig.kt
+++ b/ketch/src/main/java/com/ketch/ButtonTextConfig.kt
@@ -1,0 +1,12 @@
+package com.ketch
+
+import com.ketch.internal.utils.NotificationConst
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ButtonTextConfig(
+    val cancel: String = NotificationConst.CANCEL_BUTTON_TEXT,
+    val pause: String = NotificationConst.PAUSE_BUTTON_TEXT,
+    val resume: String = NotificationConst.RESUME_BUTTON_TEXT,
+    val retry: String = NotificationConst.RETRY_BUTTON_TEXT
+)

--- a/ketch/src/main/java/com/ketch/Ketch.kt
+++ b/ketch/src/main/java/com/ketch/Ketch.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.work.WorkManager
 import com.ketch.internal.database.DatabaseInstance
 import com.ketch.internal.download.ApiResponseHeaderChecker
+import com.ketch.internal.download.DownloadContentTexts
 import com.ketch.internal.download.DownloadManager
 import com.ketch.internal.download.DownloadRequest
 import com.ketch.internal.download.DownloadTitles
@@ -89,6 +90,7 @@ class Ketch private constructor(
     private val context: Context,
     private var downloadConfig: DownloadConfig,
     private var notificationConfig: NotificationConfig,
+    private var buttonTextConfig: ButtonTextConfig,
     private var logger: Logger,
     private var okHttpClient: OkHttpClient
 ) {
@@ -107,6 +109,7 @@ class Ketch private constructor(
             private var notificationConfig: NotificationConfig = NotificationConfig(
                 smallIcon = NotificationConst.DEFAULT_VALUE_NOTIFICATION_SMALL_ICON
             )
+            private var buttonTextConfig: ButtonTextConfig = ButtonTextConfig()
             private var logger: Logger = DownloadLogger(false)
             private lateinit var okHttpClient: OkHttpClient
 
@@ -122,6 +125,10 @@ class Ketch private constructor(
 
             fun setNotificationConfig(config: NotificationConfig) = apply {
                 this.notificationConfig = config
+            }
+
+            fun setButtonTextConfig(config: ButtonTextConfig) = apply {
+                this.buttonTextConfig = config
             }
 
             fun enableLogs(enable: Boolean) = apply {
@@ -152,6 +159,7 @@ class Ketch private constructor(
                         context = context.applicationContext,
                         downloadConfig = downloadConfig,
                         notificationConfig = notificationConfig,
+                        buttonTextConfig = buttonTextConfig,
                         logger = logger,
                         okHttpClient = okHttpClient
                     )
@@ -171,6 +179,7 @@ class Ketch private constructor(
         workManager = WorkManager.getInstance(context.applicationContext),
         downloadConfig = downloadConfig,
         notificationConfig = notificationConfig,
+        buttonTextConfig = buttonTextConfig,
         logger = logger
     )
 
@@ -194,7 +203,8 @@ class Ketch private constructor(
         metaData: String = "",
         headers: HashMap<String, String> = hashMapOf(),
         supportPauseResume: Boolean = true,
-        downloadTitles: DownloadTitles? = null
+        downloadTitles: DownloadTitles? = null,
+        downloadContentTexts: DownloadContentTexts? = null
     ): Int {
         val downloadRequest = prepareDownloadRequest(
             url = url,
@@ -204,7 +214,8 @@ class Ketch private constructor(
             headers = headers,
             metaData = metaData,
             supportPauseResume = supportPauseResume,
-            downloadTitles = downloadTitles
+            downloadTitles = downloadTitles,
+            downloadContentTexts = downloadContentTexts
         )
         downloadManager.downloadAsync(downloadRequest)
         return downloadRequest.id
@@ -229,7 +240,8 @@ class Ketch private constructor(
         metaData: String = "",
         headers: HashMap<String, String> = hashMapOf(),
         supportPauseResume: Boolean = true,
-        downloadTitles: DownloadTitles? = null
+        downloadTitles: DownloadTitles? = null,
+        downloadContentTexts: DownloadContentTexts? = null
     ): Int {
         val downloadRequest = mutex.withLock {
             prepareDownloadRequest(
@@ -240,7 +252,8 @@ class Ketch private constructor(
                 headers = headers,
                 metaData = metaData,
                 supportPauseResume = supportPauseResume,
-                downloadTitles = downloadTitles
+                downloadTitles = downloadTitles,
+                downloadContentTexts = downloadContentTexts
             )
         }
         downloadManager.download(downloadRequest)
@@ -556,7 +569,8 @@ class Ketch private constructor(
         headers: HashMap<String, String>,
         metaData: String,
         supportPauseResume: Boolean,
-        downloadTitles: DownloadTitles?
+        downloadTitles: DownloadTitles?,
+        downloadContentTexts: DownloadContentTexts?
     ): DownloadRequest {
         require(url.isNotEmpty() && path.isNotEmpty() && fileName.isNotEmpty()) {
             "Missing ${if (url.isEmpty()) "url" else if (path.isEmpty()) "path" else "fileName"}"
@@ -575,7 +589,8 @@ class Ketch private constructor(
             headers = headers,
             metaData = metaData,
             supportPauseResume = supportPauseResume,
-            downloadTitles = downloadTitles
+            downloadTitles = downloadTitles,
+            downloadContentTexts = downloadContentTexts
         )
 
         return downloadRequest

--- a/ketch/src/main/java/com/ketch/Ketch.kt
+++ b/ketch/src/main/java/com/ketch/Ketch.kt
@@ -6,6 +6,7 @@ import com.ketch.internal.database.DatabaseInstance
 import com.ketch.internal.download.ApiResponseHeaderChecker
 import com.ketch.internal.download.DownloadManager
 import com.ketch.internal.download.DownloadRequest
+import com.ketch.internal.download.DownloadTitles
 import com.ketch.internal.network.RetrofitInstance
 import com.ketch.internal.utils.DownloadConst
 import com.ketch.internal.utils.DownloadLogger
@@ -193,6 +194,7 @@ class Ketch private constructor(
         metaData: String = "",
         headers: HashMap<String, String> = hashMapOf(),
         supportPauseResume: Boolean = true,
+        downloadTitles: DownloadTitles? = null
     ): Int {
         val downloadRequest = prepareDownloadRequest(
             url = url,
@@ -202,6 +204,7 @@ class Ketch private constructor(
             headers = headers,
             metaData = metaData,
             supportPauseResume = supportPauseResume,
+            downloadTitles = downloadTitles
         )
         downloadManager.downloadAsync(downloadRequest)
         return downloadRequest.id
@@ -226,6 +229,7 @@ class Ketch private constructor(
         metaData: String = "",
         headers: HashMap<String, String> = hashMapOf(),
         supportPauseResume: Boolean = true,
+        downloadTitles: DownloadTitles? = null
     ): Int {
         val downloadRequest = mutex.withLock {
             prepareDownloadRequest(
@@ -236,6 +240,7 @@ class Ketch private constructor(
                 headers = headers,
                 metaData = metaData,
                 supportPauseResume = supportPauseResume,
+                downloadTitles = downloadTitles
             )
         }
         downloadManager.download(downloadRequest)
@@ -551,6 +556,7 @@ class Ketch private constructor(
         headers: HashMap<String, String>,
         metaData: String,
         supportPauseResume: Boolean,
+        downloadTitles: DownloadTitles?
     ): DownloadRequest {
         require(url.isNotEmpty() && path.isNotEmpty() && fileName.isNotEmpty()) {
             "Missing ${if (url.isEmpty()) "url" else if (path.isEmpty()) "path" else "fileName"}"
@@ -569,6 +575,7 @@ class Ketch private constructor(
             headers = headers,
             metaData = metaData,
             supportPauseResume = supportPauseResume,
+            downloadTitles = downloadTitles
         )
 
         return downloadRequest

--- a/ketch/src/main/java/com/ketch/NotificationConfig.kt
+++ b/ketch/src/main/java/com/ketch/NotificationConfig.kt
@@ -12,5 +12,21 @@ data class NotificationConfig(
     val showSpeed: Boolean = true,
     val showSize: Boolean = true,
     val showTime: Boolean = true,
-    val smallIcon: Int
+    val smallIcon: Int,
+    val smallIcons: NotificationSmallIconConfig = NotificationSmallIconConfig(
+        progress = smallIcon,
+        success = smallIcon,
+        failed = smallIcon,
+        paused = smallIcon,
+        cancelled = smallIcon
+    )
+)
+
+@Serializable
+data class NotificationSmallIconConfig(
+    val progress: Int,
+    val success: Int,
+    val failed: Int,
+    val paused: Int,
+    val cancelled: Int
 )

--- a/ketch/src/main/java/com/ketch/internal/database/DownloadDao.kt
+++ b/ketch/src/main/java/com/ketch/internal/database/DownloadDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
+import com.ketch.Status
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -43,10 +44,10 @@ internal interface DownloadDao {
     fun getAllEntityByTagsFlow(tags: List<String>): Flow<List<DownloadEntity>>
 
     @Query("SELECT * FROM downloads WHERE status = :status ORDER BY timeQueued ASC")
-    fun getAllEntityByStatusFlow(status: String): Flow<List<DownloadEntity>>
+    fun getAllEntityByStatusFlow(status: Status): Flow<List<DownloadEntity>>
 
     @Query("SELECT * FROM downloads WHERE status IN (:statuses) ORDER BY timeQueued ASC")
-    fun getAllEntityByStatusesFlow(statuses: List<String>): Flow<List<DownloadEntity>>
+    fun getAllEntityByStatusesFlow(statuses: List<Status>): Flow<List<DownloadEntity>>
 
     @Query("SELECT * FROM downloads ORDER BY timeQueued ASC")
     suspend fun getAllEntity(): List<DownloadEntity>
@@ -64,8 +65,8 @@ internal interface DownloadDao {
     suspend fun getAllEntityByIds(ids: List<Int>): List<DownloadEntity?>
 
     @Query("SELECT * FROM downloads WHERE status = :status ORDER BY timeQueued ASC")
-    suspend fun getAllEntityByStatus(status: String): List<DownloadEntity>
+    suspend fun getAllEntityByStatus(status: Status): List<DownloadEntity>
 
     @Query("SELECT * FROM downloads WHERE status IN (:statuses) ORDER BY timeQueued ASC")
-    suspend fun getAllEntityByStatuses(statuses: List<String>): List<DownloadEntity>
+    suspend fun getAllEntityByStatuses(statuses: List<Status>): List<DownloadEntity>
 }

--- a/ketch/src/main/java/com/ketch/internal/database/DownloadDatabase.kt
+++ b/ketch/src/main/java/com/ketch/internal/database/DownloadDatabase.kt
@@ -3,7 +3,7 @@ package com.ketch.internal.database
 import androidx.room.Database
 import androidx.room.RoomDatabase
 
-@Database(entities = [DownloadEntity::class], version = 1)
+@Database(entities = [DownloadEntity::class], version = 2)
 internal abstract class DownloadDatabase : RoomDatabase() {
     abstract fun downloadDao(): DownloadDao
 }

--- a/ketch/src/main/java/com/ketch/internal/database/DownloadDatabase.kt
+++ b/ketch/src/main/java/com/ketch/internal/database/DownloadDatabase.kt
@@ -3,7 +3,7 @@ package com.ketch.internal.database
 import androidx.room.Database
 import androidx.room.RoomDatabase
 
-@Database(entities = [DownloadEntity::class], version = 2)
+@Database(entities = [DownloadEntity::class], version = 3)
 internal abstract class DownloadDatabase : RoomDatabase() {
     abstract fun downloadDao(): DownloadDao
 }

--- a/ketch/src/main/java/com/ketch/internal/database/DownloadEntity.kt
+++ b/ketch/src/main/java/com/ketch/internal/database/DownloadEntity.kt
@@ -3,6 +3,7 @@ package com.ketch.internal.database
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.ketch.Status
+import com.ketch.internal.download.DownloadProgressContentText
 import com.ketch.internal.utils.UserAction
 
 @Entity(
@@ -18,12 +19,15 @@ internal data class DownloadEntity(
     var successTitle: String = "",
     var canceledTitle: String = "",
     var pausedTitle: String = "",
-
-    var progressContentText: String= "",
-    val failedContentText: String= "",
-    val successContentText: String= "",
-    val canceledContentText: String= "",
-    val pausedContentText: String= "",
+    val progressContentTextOnlySeconds: String,
+    val progressContentTextOnlyMinutes: String,
+    val progressContentTextOnlyHours: String,
+    val progressContentTextMinutesAndSeconds: String,
+    val progressContentTextHoursAndMinutes: String,
+    val failedContentText: String = "",
+    val successContentText: String = "",
+    val canceledContentText: String = "",
+    val pausedContentText: String = "",
 
     @PrimaryKey
     var id: Int = 0,

--- a/ketch/src/main/java/com/ketch/internal/database/DownloadEntity.kt
+++ b/ketch/src/main/java/com/ketch/internal/database/DownloadEntity.kt
@@ -13,6 +13,11 @@ internal data class DownloadEntity(
     var path: String = "",
     var fileName: String = "",
     var tag: String = "",
+    var progressTitle: String = "",
+    var failedTitle: String = "",
+    var successTitle: String = "",
+    var canceledTitle: String = "",
+    var pausedTitle: String = "",
     @PrimaryKey
     var id: Int = 0,
     var headersJson: String = "",

--- a/ketch/src/main/java/com/ketch/internal/database/DownloadEntity.kt
+++ b/ketch/src/main/java/com/ketch/internal/database/DownloadEntity.kt
@@ -18,6 +18,13 @@ internal data class DownloadEntity(
     var successTitle: String = "",
     var canceledTitle: String = "",
     var pausedTitle: String = "",
+
+    var progressContentText: String= "",
+    val failedContentText: String= "",
+    val successContentText: String= "",
+    val canceledContentText: String= "",
+    val pausedContentText: String= "",
+
     @PrimaryKey
     var id: Int = 0,
     var headersJson: String = "",

--- a/ketch/src/main/java/com/ketch/internal/database/DownloadEntity.kt
+++ b/ketch/src/main/java/com/ketch/internal/database/DownloadEntity.kt
@@ -3,7 +3,6 @@ package com.ketch.internal.database
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.ketch.Status
-import com.ketch.internal.download.DownloadProgressContentText
 import com.ketch.internal.utils.UserAction
 
 @Entity(
@@ -14,20 +13,8 @@ internal data class DownloadEntity(
     var path: String = "",
     var fileName: String = "",
     var tag: String = "",
-    var progressTitle: String = "",
-    var failedTitle: String = "",
-    var successTitle: String = "",
-    var canceledTitle: String = "",
-    var pausedTitle: String = "",
-    val progressContentTextOnlySeconds: String,
-    val progressContentTextOnlyMinutes: String,
-    val progressContentTextOnlyHours: String,
-    val progressContentTextMinutesAndSeconds: String,
-    val progressContentTextHoursAndMinutes: String,
-    val failedContentText: String = "",
-    val successContentText: String = "",
-    val canceledContentText: String = "",
-    val pausedContentText: String = "",
+    val downloadTitles: String = "",
+    val downloadContentTexts: String = "",
 
     @PrimaryKey
     var id: Int = 0,

--- a/ketch/src/main/java/com/ketch/internal/database/DownloadEntity.kt
+++ b/ketch/src/main/java/com/ketch/internal/database/DownloadEntity.kt
@@ -17,14 +17,14 @@ internal data class DownloadEntity(
     var id: Int = 0,
     var headersJson: String = "",
     var timeQueued: Long = 0,
-    var status: String = Status.DEFAULT.toString(),
+    var status: Status = Status.DEFAULT,
     var totalBytes: Long = 0,
     var downloadedBytes: Long = 0,
     var speedInBytePerMs: Float = 0f,
     var uuid: String = "",
     var lastModified: Long = 0,
     var eTag: String = "",
-    var userAction: String = UserAction.DEFAULT.toString(),
+    var userAction: UserAction = UserAction.DEFAULT,
     var metaData: String = "",
     var failureReason: String = ""
 )

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadManager.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadManager.kt
@@ -7,6 +7,7 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
+import com.ketch.ButtonTextConfig
 import com.ketch.DownloadConfig
 import com.ketch.DownloadModel
 import com.ketch.Logger
@@ -41,6 +42,7 @@ internal class DownloadManager(
     private val workManager: WorkManager,
     private val downloadConfig: DownloadConfig,
     private val notificationConfig: NotificationConfig,
+    private val buttonTextConfig: ButtonTextConfig,
     private val logger: Logger
 ) {
 
@@ -138,6 +140,7 @@ internal class DownloadManager(
         val inputDataBuilder = Data.Builder()
             .putString(DownloadConst.KEY_DOWNLOAD_REQUEST, downloadRequest.toJson())
             .putString(DownloadConst.KEY_NOTIFICATION_CONFIG, notificationConfig.toJson())
+            .putString(DownloadConst.KEY_BUTTON_TEXT_CONFIG, buttonTextConfig.toJson())
 
         val inputData = inputDataBuilder.build()
 
@@ -190,7 +193,20 @@ internal class DownloadManager(
                     uuid = downloadWorkRequest.id.toString(),
                     lastModified = System.currentTimeMillis(),
                     userAction = UserAction.START.toString(),
-                    metaData = downloadRequest.metaData
+                    metaData = downloadRequest.metaData,
+                    progressTitle = downloadRequest.downloadTitles?.progressTitle ?: "",
+                    failedTitle = downloadRequest.downloadTitles?.failedTitle ?: "",
+                    successTitle = downloadRequest.downloadTitles?.successTitle ?: "",
+                    canceledTitle = downloadRequest.downloadTitles?.canceledTitle ?: "",
+                    pausedTitle = downloadRequest.downloadTitles?.pausedTitle ?: "",
+                    failedContentText = downloadRequest.downloadContentTexts?.failedContentText
+                        ?: "",
+                    successContentText = downloadRequest.downloadContentTexts?.successContentText
+                        ?: "",
+                    canceledContentText = downloadRequest.downloadContentTexts?.canceledContentText
+                        ?: "",
+                    pausedContentText = downloadRequest.downloadContentTexts?.pausedContentText
+                        ?: ""
                 )
             )
         }
@@ -219,7 +235,20 @@ internal class DownloadManager(
                     tag = downloadEntity.tag,
                     id = downloadEntity.id,
                     headers = WorkUtil.jsonToHashMap(downloadEntity.headersJson),
-                    metaData = downloadEntity.metaData
+                    metaData = downloadEntity.metaData,
+                    downloadTitles = DownloadTitles(
+                        progressTitle = downloadEntity.progressTitle,
+                        successTitle = downloadEntity.successTitle,
+                        failedTitle = downloadEntity.failedTitle,
+                        canceledTitle = downloadEntity.canceledTitle,
+                        pausedTitle = downloadEntity.pausedTitle
+                    ),
+                    downloadContentTexts = DownloadContentTexts(
+                        successContentText = downloadEntity.successContentText,
+                        failedContentText = downloadEntity.failedContentText,
+                        canceledContentText = downloadEntity.canceledContentText,
+                        pausedContentText = downloadEntity.pausedContentText
+                    )
                 )
             )
         }
@@ -246,6 +275,7 @@ internal class DownloadManager(
                 DownloadNotificationManager(
                     context = context,
                     notificationConfig = notificationConfig,
+                    buttonTextConfig = buttonTextConfig,
                     requestId = id,
                     fileName = downloadEntity.fileName,
                     downloadTitles = DownloadTitles(
@@ -255,6 +285,12 @@ internal class DownloadManager(
                         canceledTitle = downloadEntity.canceledTitle,
                         pausedTitle = downloadEntity.pausedTitle,
                     ),
+                    downloadContentTexts = DownloadContentTexts(
+                        failedContentText = downloadEntity.failedContentText,
+                        successContentText = downloadEntity.successContentText,
+                        canceledContentText = downloadEntity.canceledContentText,
+                        pausedContentText = downloadEntity.pausedContentText
+                    )
                 ).sendDownloadCancelledNotification()
             }
         }
@@ -291,7 +327,20 @@ internal class DownloadManager(
                     tag = downloadEntity.tag,
                     id = downloadEntity.id,
                     headers = WorkUtil.jsonToHashMap(downloadEntity.headersJson),
-                    metaData = downloadEntity.metaData
+                    metaData = downloadEntity.metaData,
+                    downloadTitles = DownloadTitles(
+                        progressTitle = downloadEntity.progressTitle,
+                        failedTitle = downloadEntity.failedTitle,
+                        successTitle = downloadEntity.successTitle,
+                        canceledTitle = downloadEntity.canceledTitle,
+                        pausedTitle = downloadEntity.pausedTitle,
+                    ),
+                    downloadContentTexts = DownloadContentTexts(
+                        failedContentText = downloadEntity.failedContentText,
+                        successContentText = downloadEntity.successContentText,
+                        canceledContentText = downloadEntity.canceledContentText,
+                        pausedContentText = downloadEntity.pausedContentText
+                    )
                 )
             )
         }

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadManager.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadManager.kt
@@ -196,29 +196,8 @@ internal class DownloadManager(
                     lastModified = System.currentTimeMillis(),
                     userAction = UserAction.START.toString(),
                     metaData = downloadRequest.metaData,
-                    progressTitle = downloadRequest.downloadTitles?.progressTitle ?: "",
-                    failedTitle = downloadRequest.downloadTitles?.failedTitle ?: "",
-                    successTitle = downloadRequest.downloadTitles?.successTitle ?: "",
-                    canceledTitle = downloadRequest.downloadTitles?.canceledTitle ?: "",
-                    pausedTitle = downloadRequest.downloadTitles?.pausedTitle ?: "",
-                    failedContentText = downloadRequest.downloadContentTexts?.failedContentText
-                        ?: "",
-                    successContentText = downloadRequest.downloadContentTexts?.successContentText
-                        ?: "",
-                    canceledContentText = downloadRequest.downloadContentTexts?.canceledContentText
-                        ?: "",
-                    pausedContentText = downloadRequest.downloadContentTexts?.pausedContentText
-                        ?: "",
-                    progressContentTextOnlySeconds = downloadRequest.downloadContentTexts?.progressContentText?.onlySeconds
-                        ?: "",
-                    progressContentTextOnlyMinutes = downloadRequest.downloadContentTexts?.progressContentText?.onlySeconds
-                        ?: "",
-                    progressContentTextOnlyHours = downloadRequest.downloadContentTexts?.progressContentText?.onlyMinutes
-                        ?: "",
-                    progressContentTextMinutesAndSeconds = downloadRequest.downloadContentTexts?.progressContentText?.minutesAndSeconds
-                        ?: "",
-                    progressContentTextHoursAndMinutes = downloadRequest.downloadContentTexts?.progressContentText?.hoursAndMinutes
-                        ?: ""
+                    downloadTitles = downloadRequest.downloadTitles?.toJson() ?: "",
+                    downloadContentTexts = downloadRequest.downloadContentTexts?.toJson() ?: ""
                 )
             )
         }
@@ -248,26 +227,8 @@ internal class DownloadManager(
                     id = downloadEntity.id,
                     headers = WorkUtil.jsonToHashMap(downloadEntity.headersJson),
                     metaData = downloadEntity.metaData,
-                    downloadTitles = DownloadTitles(
-                        progressTitle = downloadEntity.progressTitle,
-                        successTitle = downloadEntity.successTitle,
-                        failedTitle = downloadEntity.failedTitle,
-                        canceledTitle = downloadEntity.canceledTitle,
-                        pausedTitle = downloadEntity.pausedTitle
-                    ),
-                    downloadContentTexts = DownloadContentTexts(
-                        successContentText = downloadEntity.successContentText,
-                        failedContentText = downloadEntity.failedContentText,
-                        canceledContentText = downloadEntity.canceledContentText,
-                        pausedContentText = downloadEntity.pausedContentText,
-                        progressContentText = DownloadProgressContentText(
-                            onlySeconds = downloadEntity.progressContentTextOnlySeconds,
-                            onlyMinutes = downloadEntity.progressContentTextOnlyMinutes,
-                            onlyHours = downloadEntity.progressContentTextOnlyHours,
-                            minutesAndSeconds = downloadEntity.progressContentTextMinutesAndSeconds,
-                            hoursAndMinutes = downloadEntity.progressContentTextHoursAndMinutes
-                        )
-                    )
+                    downloadTitles = WorkUtil.jsonToDownloadTitles(downloadEntity.downloadTitles),
+                    downloadContentTexts = WorkUtil.jsonToDownloadContentTexts(downloadEntity.downloadContentTexts)
                 )
             )
         }
@@ -297,26 +258,8 @@ internal class DownloadManager(
                     buttonTextConfig = buttonTextConfig,
                     requestId = id,
                     fileName = downloadEntity.fileName,
-                    downloadTitles = DownloadTitles(
-                        progressTitle = downloadEntity.progressTitle,
-                        failedTitle = downloadEntity.failedTitle,
-                        successTitle = downloadEntity.successTitle,
-                        canceledTitle = downloadEntity.canceledTitle,
-                        pausedTitle = downloadEntity.pausedTitle,
-                    ),
-                    downloadContentTexts = DownloadContentTexts(
-                        failedContentText = downloadEntity.failedContentText,
-                        successContentText = downloadEntity.successContentText,
-                        canceledContentText = downloadEntity.canceledContentText,
-                        pausedContentText = downloadEntity.pausedContentText,
-                        progressContentText = DownloadProgressContentText(
-                            onlySeconds = downloadEntity.progressContentTextOnlySeconds,
-                            onlyMinutes = downloadEntity.progressContentTextOnlyMinutes,
-                            onlyHours = downloadEntity.progressContentTextOnlyHours,
-                            minutesAndSeconds = downloadEntity.progressContentTextMinutesAndSeconds,
-                            hoursAndMinutes = downloadEntity.progressContentTextHoursAndMinutes
-                        )
-                    )
+                    downloadTitles = WorkUtil.jsonToDownloadTitles(downloadEntity.downloadTitles),
+                    downloadContentTexts = WorkUtil.jsonToDownloadContentTexts(downloadEntity.downloadContentTexts)
                 ).sendDownloadCancelledNotification()
             }
         }
@@ -354,26 +297,8 @@ internal class DownloadManager(
                     id = downloadEntity.id,
                     headers = WorkUtil.jsonToHashMap(downloadEntity.headersJson),
                     metaData = downloadEntity.metaData,
-                    downloadTitles = DownloadTitles(
-                        progressTitle = downloadEntity.progressTitle,
-                        failedTitle = downloadEntity.failedTitle,
-                        successTitle = downloadEntity.successTitle,
-                        canceledTitle = downloadEntity.canceledTitle,
-                        pausedTitle = downloadEntity.pausedTitle,
-                    ),
-                    downloadContentTexts = DownloadContentTexts(
-                        failedContentText = downloadEntity.failedContentText,
-                        successContentText = downloadEntity.successContentText,
-                        canceledContentText = downloadEntity.canceledContentText,
-                        pausedContentText = downloadEntity.pausedContentText,
-                        progressContentText = DownloadProgressContentText(
-                            onlySeconds = downloadEntity.progressContentTextOnlySeconds,
-                            onlyMinutes = downloadEntity.progressContentTextOnlyMinutes,
-                            onlyHours = downloadEntity.progressContentTextOnlyHours,
-                            minutesAndSeconds = downloadEntity.progressContentTextMinutesAndSeconds,
-                            hoursAndMinutes = downloadEntity.progressContentTextHoursAndMinutes
-                        )
-                    )
+                    downloadTitles = WorkUtil.jsonToDownloadTitles(downloadEntity.downloadTitles),
+                    downloadContentTexts = WorkUtil.jsonToDownloadContentTexts(downloadEntity.downloadContentTexts)
                 )
             )
         }

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadManager.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadManager.kt
@@ -85,11 +85,13 @@ internal class DownloadManager(
                                             msg = "Download in Progress. FileName: ${downloadEntity?.fileName}, " +
                                                     "ID: ${downloadEntity?.id}, " +
                                                     "Size in bytes: ${downloadEntity?.totalBytes}, " +
-                                                    "downloadPercent: ${if (downloadEntity != null && downloadEntity.totalBytes.toInt() != 0) {
-                                                        ((downloadEntity.downloadedBytes * 100) / downloadEntity.totalBytes).toInt()
-                                                    } else {
-                                                        0
-                                                    }}%, " +
+                                                    "downloadPercent: ${
+                                                        if (downloadEntity != null && downloadEntity.totalBytes.toInt() != 0) {
+                                                            ((downloadEntity.downloadedBytes * 100) / downloadEntity.totalBytes).toInt()
+                                                        } else {
+                                                            0
+                                                        }
+                                                    }%, " +
                                                     "downloadSpeedInBytesPerMilliSeconds: ${downloadEntity?.speedInBytePerMs} b/ms"
                                         )
 
@@ -206,6 +208,16 @@ internal class DownloadManager(
                     canceledContentText = downloadRequest.downloadContentTexts?.canceledContentText
                         ?: "",
                     pausedContentText = downloadRequest.downloadContentTexts?.pausedContentText
+                        ?: "",
+                    progressContentTextOnlySeconds = downloadRequest.downloadContentTexts?.progressContentText?.onlySeconds
+                        ?: "",
+                    progressContentTextOnlyMinutes = downloadRequest.downloadContentTexts?.progressContentText?.onlySeconds
+                        ?: "",
+                    progressContentTextOnlyHours = downloadRequest.downloadContentTexts?.progressContentText?.onlyMinutes
+                        ?: "",
+                    progressContentTextMinutesAndSeconds = downloadRequest.downloadContentTexts?.progressContentText?.minutesAndSeconds
+                        ?: "",
+                    progressContentTextHoursAndMinutes = downloadRequest.downloadContentTexts?.progressContentText?.hoursAndMinutes
                         ?: ""
                 )
             )
@@ -247,7 +259,14 @@ internal class DownloadManager(
                         successContentText = downloadEntity.successContentText,
                         failedContentText = downloadEntity.failedContentText,
                         canceledContentText = downloadEntity.canceledContentText,
-                        pausedContentText = downloadEntity.pausedContentText
+                        pausedContentText = downloadEntity.pausedContentText,
+                        progressContentText = DownloadProgressContentText(
+                            onlySeconds = downloadEntity.progressContentTextOnlySeconds,
+                            onlyMinutes = downloadEntity.progressContentTextOnlyMinutes,
+                            onlyHours = downloadEntity.progressContentTextOnlyHours,
+                            minutesAndSeconds = downloadEntity.progressContentTextMinutesAndSeconds,
+                            hoursAndMinutes = downloadEntity.progressContentTextHoursAndMinutes
+                        )
                     )
                 )
             )
@@ -289,7 +308,14 @@ internal class DownloadManager(
                         failedContentText = downloadEntity.failedContentText,
                         successContentText = downloadEntity.successContentText,
                         canceledContentText = downloadEntity.canceledContentText,
-                        pausedContentText = downloadEntity.pausedContentText
+                        pausedContentText = downloadEntity.pausedContentText,
+                        progressContentText = DownloadProgressContentText(
+                            onlySeconds = downloadEntity.progressContentTextOnlySeconds,
+                            onlyMinutes = downloadEntity.progressContentTextOnlyMinutes,
+                            onlyHours = downloadEntity.progressContentTextOnlyHours,
+                            minutesAndSeconds = downloadEntity.progressContentTextMinutesAndSeconds,
+                            hoursAndMinutes = downloadEntity.progressContentTextHoursAndMinutes
+                        )
                     )
                 ).sendDownloadCancelledNotification()
             }
@@ -339,7 +365,14 @@ internal class DownloadManager(
                         failedContentText = downloadEntity.failedContentText,
                         successContentText = downloadEntity.successContentText,
                         canceledContentText = downloadEntity.canceledContentText,
-                        pausedContentText = downloadEntity.pausedContentText
+                        pausedContentText = downloadEntity.pausedContentText,
+                        progressContentText = DownloadProgressContentText(
+                            onlySeconds = downloadEntity.progressContentTextOnlySeconds,
+                            onlyMinutes = downloadEntity.progressContentTextOnlyMinutes,
+                            onlyHours = downloadEntity.progressContentTextOnlyHours,
+                            minutesAndSeconds = downloadEntity.progressContentTextMinutesAndSeconds,
+                            hoursAndMinutes = downloadEntity.progressContentTextHoursAndMinutes
+                        )
                     )
                 )
             )

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadManager.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadManager.kt
@@ -85,13 +85,11 @@ internal class DownloadManager(
                                             msg = "Download in Progress. FileName: ${downloadEntity?.fileName}, " +
                                                     "ID: ${downloadEntity?.id}, " +
                                                     "Size in bytes: ${downloadEntity?.totalBytes}, " +
-                                                    "downloadPercent: ${
-                                                        if (downloadEntity != null && downloadEntity.totalBytes.toInt() != 0) {
-                                                            ((downloadEntity.downloadedBytes * 100) / downloadEntity.totalBytes).toInt()
-                                                        } else {
-                                                            0
-                                                        }
-                                                    }%, " +
+                                                    "downloadPercent: ${if (downloadEntity != null && downloadEntity.totalBytes.toInt() != 0) {
+                                                        ((downloadEntity.downloadedBytes * 100) / downloadEntity.totalBytes).toInt()
+                                                    } else {
+                                                        0
+                                                    }}%, " +
                                                     "downloadSpeedInBytesPerMilliSeconds: ${downloadEntity?.speedInBytePerMs} b/ms"
                                         )
 

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadManager.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadManager.kt
@@ -247,7 +247,14 @@ internal class DownloadManager(
                     context = context,
                     notificationConfig = notificationConfig,
                     requestId = id,
-                    fileName = downloadEntity.fileName
+                    fileName = downloadEntity.fileName,
+                    downloadTitles = DownloadTitles(
+                        progressTitle = downloadEntity.progressTitle,
+                        failedTitle = downloadEntity.failedTitle,
+                        successTitle = downloadEntity.successTitle,
+                        canceledTitle = downloadEntity.canceledTitle,
+                        pausedTitle = downloadEntity.pausedTitle,
+                    ),
                 ).sendDownloadCancelledNotification()
             }
         }

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadManager.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadManager.kt
@@ -204,7 +204,8 @@ internal class DownloadManager(
 
     private suspend fun resume(id: Int) {
         val downloadEntity = downloadDao.find(id)
-        if (downloadEntity != null) {
+        if (downloadEntity != null && (downloadEntity.status!= Status.PROGRESS.toString() &&
+                downloadEntity.status!= Status.SUCCESS.toString())) {
             downloadDao.update(
                 downloadEntity.copy(
                     userAction = UserAction.RESUME.toString(),

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadRequest.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadRequest.kt
@@ -13,5 +13,6 @@ internal data class DownloadRequest(
     val headers: HashMap<String, String> = hashMapOf(),
     val metaData: String = "",
     val supportPauseResume: Boolean = true,
-    val downloadTitles: DownloadTitles? = null
+    val downloadTitles: DownloadTitles? = null,
+    val downloadContentTexts: DownloadContentTexts? = null
 )

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadRequest.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadRequest.kt
@@ -13,4 +13,5 @@ internal data class DownloadRequest(
     val headers: HashMap<String, String> = hashMapOf(),
     val metaData: String = "",
     val supportPauseResume: Boolean = true,
+    val downloadTitles: DownloadTitles? = null
 )

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadTask.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadTask.kt
@@ -7,11 +7,11 @@ import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
 
+
 internal class DownloadTask(
-    private val url: String,
-    private val path: String,
-    private val fileName: String,
-    private val supportPauseResume: Boolean = true,
+    private var url: String,
+    private var path: String,
+    private var fileName: String,
     private val downloadService: DownloadService,
 ) {
 
@@ -19,65 +19,83 @@ internal class DownloadTask(
         private const val VALUE_200 = 200
         private const val VALUE_299 = 299
         private const val TIME_TO_TRIGGER_PROGRESS = 1500
+        private const val TAG = "DownloadTask"
     }
 
     suspend fun download(
         headers: MutableMap<String, String> = mutableMapOf(),
-        onStart: suspend (totalBytes: Long) -> Unit,
-        onProgress: suspend (progressBytes: Long, totalBytes: Long, speed: Float) -> Unit
+        onStart: suspend (Long) -> Unit,
+        onProgress: suspend (Long, Long, Float) -> Unit
     ): Long {
 
-        var rangeStart = 0L
         val file = File(path, fileName)
         val tempFile = FileUtil.getTempFileForFile(file)
 
+        var rangeStart = 0L
         if (tempFile.exists()) {
             rangeStart = tempFile.length()
+            println("$TAG: Found existing temp file with size: $rangeStart bytes")
         }
 
-        if (rangeStart != 0L) {
+        if (rangeStart > 0) {
             headers[DownloadConst.RANGE_HEADER] = "bytes=$rangeStart-"
+            println("$TAG: Attempting to resume download from $rangeStart bytes")
         }
 
         var response = downloadService.getUrl(url, headers)
-        if (response.code() == DownloadConst.HTTP_RANGE_NOT_SATISFY || isRedirection(
-                response.raw().request().url().toString()
-            )
-        ) {
-            FileUtil.deleteFileIfExists(path, fileName)
+
+        if (response.code() == DownloadConst.HTTP_RANGE_NOT_SATISFY) {
+            println("$TAG: Server returned 416 Range Not Satisfiable")
+
+            if (file.exists() && file.length() > 0) {
+                println("$TAG: File seems to be completely downloaded already")
+                tempFile.parent?.let { FileUtil.deleteFileIfExists(it, tempFile.name) }
+                return file.length()
+            }
+
+            println("$TAG: Restarting download from beginning")
+            tempFile.parent?.let { FileUtil.deleteFileIfExists(it, tempFile.name) }
             headers.remove(DownloadConst.RANGE_HEADER)
             rangeStart = 0
             response = downloadService.getUrl(url, headers)
+        } else if (isRedirection(response.raw().request().url().toString())) {
+            println("$TAG: URL redirection detected, updating URL")
+            url = response.raw().request().url().toString()
+            if (rangeStart > 0) {
+                println("$TAG: Continuing with range request after redirection")
+                response = downloadService.getUrl(url, headers)
+            }
         }
 
-        val responseBody = response.body()
+        var responseBody = response.body()
 
-        if (response.code() !in VALUE_200..VALUE_299 ||
-            responseBody == null
-        ) {
+        if (response.code() !in VALUE_200..VALUE_299 || responseBody == null) {
             throw IOException(
                 "Something went wrong, response code: ${response.code()}, responseBody null: ${responseBody == null}"
             )
         }
 
-        var totalBytes = responseBody.contentLength()
-
-        // pause resume not supported if we can not get content length or not supported by user
-        if (totalBytes < 0 || supportPauseResume.not()) {
-            totalBytes = 0
-        } else {
-            totalBytes += rangeStart
+        if (rangeStart > 0 && response.code() != 206) {
+            println("$TAG: Server doesn't support resume properly (no 206 response). Restarting download.")
+            tempFile.parent?.let { FileUtil.deleteFileIfExists(it, tempFile.name) }
+            headers.remove(DownloadConst.RANGE_HEADER)
+            rangeStart = 0
+            response = downloadService.getUrl(url, headers)
+            responseBody.close()
+            responseBody = response.body() ?: throw IOException("Response body is null")
         }
 
-        var progressBytes = 0L
+        var totalBytes = responseBody.contentLength()
+
+        if (totalBytes < 0) throw IOException("Content Length is wrong: $totalBytes")
+
+        var progressBytes = rangeStart
+        totalBytes += rangeStart
+
+        println("$TAG: Starting download - Total size: $totalBytes bytes, Already downloaded: $rangeStart bytes")
 
         responseBody.byteStream().use { inputStream ->
-            FileOutputStream(tempFile,true).use { outputStream ->
-
-                if (rangeStart != 0L) {
-                    progressBytes = rangeStart
-                }
-
+            FileOutputStream(tempFile, rangeStart > 0).use { outputStream ->
                 onStart.invoke(totalBytes)
 
                 val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
@@ -86,36 +104,39 @@ internal class DownloadTask(
                 var progressInvokeTime = System.currentTimeMillis()
                 var speed: Float
 
-                onProgress.invoke(0L, 0L, 0F)
-
                 while (bytes >= 0) {
-
                     outputStream.write(buffer, 0, bytes)
                     progressBytes += bytes
                     tempBytes += bytes
                     bytes = inputStream.read(buffer)
                     val finalTime = System.currentTimeMillis()
                     if (finalTime - progressInvokeTime >= TIME_TO_TRIGGER_PROGRESS) {
-
-                        speed = tempBytes.toFloat() / ((finalTime - progressInvokeTime).toFloat())
+                        speed = tempBytes.toFloat() / ((finalTime - progressInvokeTime).toFloat() / 1000)
                         tempBytes = 0L
                         progressInvokeTime = System.currentTimeMillis()
                         if (progressBytes > totalBytes) progressBytes = totalBytes
-                        if(totalBytes > 0) {
-                            onProgress.invoke(
-                                progressBytes,
-                                totalBytes,
-                                speed
-                            )
-                        }
+                        onProgress.invoke(
+                            progressBytes,
+                            totalBytes,
+                            speed
+                        )
                     }
                 }
                 onProgress.invoke(totalBytes, totalBytes, 0F)
             }
         }
 
-        require(tempFile.renameTo(file)) { "Temp file rename failed" }
+        if (!tempFile.renameTo(file)) {
+            println("$TAG: Rename failed, trying to copy file")
+            tempFile.inputStream().use { input ->
+                file.outputStream().use { output ->
+                    input.copyTo(output)
+                }
+            }
+            tempFile.parent?.let { FileUtil.deleteFileIfExists(it, tempFile.name) }
+        }
 
+        println("$TAG: Download completed successfully - Total bytes: $totalBytes")
         return totalBytes
     }
 

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadTitles.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadTitles.kt
@@ -13,9 +13,18 @@ data class DownloadTitles(
 
 @Serializable
 data class DownloadContentTexts(
-    var progressContentText: String? = null,
+    var progressContentText: DownloadProgressContentText? = null,
     val failedContentText: String? = null,
     val successContentText: String? = null,
     val canceledContentText: String? = null,
     val pausedContentText: String? = null,
+)
+
+@Serializable
+data class DownloadProgressContentText(
+    val onlySeconds: String,
+    val onlyMinutes: String,
+    val onlyHours: String,
+    val minutesAndSeconds: String,
+    val hoursAndMinutes: String
 )

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadTitles.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadTitles.kt
@@ -4,10 +4,18 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class DownloadTitles(
-    var startTitle: String? = null,
     var progressTitle: String? = null,
     val failedTitle: String? = null,
     val successTitle: String? = null,
     val canceledTitle: String? = null,
     val pausedTitle: String? = null,
+)
+
+@Serializable
+data class DownloadContentTexts(
+    var progressContentText: String? = null,
+    val failedContentText: String? = null,
+    val successContentText: String? = null,
+    val canceledContentText: String? = null,
+    val pausedContentText: String? = null,
 )

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadTitles.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadTitles.kt
@@ -1,0 +1,13 @@
+package com.ketch.internal.download
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DownloadTitles(
+    var startTitle: String? = null,
+    var progressTitle: String? = null,
+    val failedTitle: String? = null,
+    val successTitle: String? = null,
+    val canceledTitle: String? = null,
+    val pausedTitle: String? = null,
+)

--- a/ketch/src/main/java/com/ketch/internal/notification/DownloadNotificationManager.kt
+++ b/ketch/src/main/java/com/ketch/internal/notification/DownloadNotificationManager.kt
@@ -184,6 +184,10 @@ internal class DownloadNotificationManager(
         progress: Int,
         length: Long
     ): String {
+        downloadContentTexts?.progressContentText?.let {
+            return TextUtil.getTextFromCustomTemplate(speedInBPerMs, progress, length, it)
+        }
+
         val timeLeftText = TextUtil.getTimeLeftText(speedInBPerMs, progress, length)
         val speedText = TextUtil.getSpeedText(speedInBPerMs)
         val lengthText = TextUtil.getTotalLengthText(length)

--- a/ketch/src/main/java/com/ketch/internal/notification/DownloadNotificationManager.kt
+++ b/ketch/src/main/java/com/ketch/internal/notification/DownloadNotificationManager.kt
@@ -11,7 +11,9 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.work.ForegroundInfo
+import com.ketch.ButtonTextConfig
 import com.ketch.NotificationConfig
+import com.ketch.internal.download.DownloadContentTexts
 import com.ketch.internal.download.DownloadTitles
 import com.ketch.internal.utils.DownloadConst
 import com.ketch.internal.utils.NotificationConst
@@ -34,9 +36,11 @@ import com.ketch.internal.utils.WorkUtil.removeNotification
 internal class DownloadNotificationManager(
     private val context: Context,
     private val notificationConfig: NotificationConfig,
+    private val buttonTextConfig: ButtonTextConfig,
     private val requestId: Int,
     private val fileName: String,
-    private val downloadTitles: DownloadTitles?
+    private val downloadTitles: DownloadTitles?,
+    private val downloadContentTexts: DownloadContentTexts?
 ) {
 
     private var foregroundInfo: ForegroundInfo? = null
@@ -149,12 +153,12 @@ internal class DownloadNotificationManager(
                 .setOngoing(true)
 
             if (length != 0L) {
-                nb = nb.addAction(-1, NotificationConst.PAUSE_BUTTON_TEXT, pendingIntentPause)
+                nb = nb.addAction(-1, buttonTextConfig.pause, pendingIntentPause)
             }
 
             foregroundInfo = ForegroundInfo(
                 notificationId,
-                nb.addAction(-1, NotificationConst.CANCEL_BUTTON_TEXT, pendingIntentCancel)
+                nb.addAction(-1, buttonTextConfig.cancel, pendingIntentCancel)
                     .setDeleteIntent(pendingIntentDismiss)
                     .build(),
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -225,7 +229,12 @@ internal class DownloadNotificationManager(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
                     notificationConfig.smallIcon
                 )
+                putExtra(NotificationConst.CANCEL_BUTTON_TEXT, buttonTextConfig.cancel)
+                putExtra(NotificationConst.PAUSE_BUTTON_TEXT, buttonTextConfig.pause)
+                putExtra(NotificationConst.RESUME_BUTTON_TEXT, buttonTextConfig.resume)
+                putExtra(NotificationConst.RETRY_BUTTON_TEXT, buttonTextConfig.retry)
                 putExtra(DownloadConst.KEY_FILE_NAME, downloadTitles?.successTitle ?: fileName)
+                putExtra(DownloadConst.KEY_CONTENT_TEXT, downloadContentTexts?.successContentText)
                 putExtra(DownloadConst.KEY_LENGTH, totalLength)
                 putExtra(DownloadConst.KEY_REQUEST_ID, requestId)
                 putExtra(NotificationConst.KEY_NOTIFICATION_ID, notificationId)
@@ -258,7 +267,13 @@ internal class DownloadNotificationManager(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
                     notificationConfig.smallIcon
                 )
+
+                putExtra(NotificationConst.CANCEL_BUTTON_TEXT, buttonTextConfig.cancel)
+                putExtra(NotificationConst.PAUSE_BUTTON_TEXT, buttonTextConfig.pause)
+                putExtra(NotificationConst.RESUME_BUTTON_TEXT, buttonTextConfig.resume)
+                putExtra(NotificationConst.RETRY_BUTTON_TEXT, buttonTextConfig.retry)
                 putExtra(DownloadConst.KEY_FILE_NAME, downloadTitles?.failedTitle ?: fileName)
+                putExtra(DownloadConst.KEY_CONTENT_TEXT, downloadContentTexts?.failedContentText)
                 putExtra(DownloadConst.KEY_REQUEST_ID, requestId)
                 putExtra(NotificationConst.KEY_NOTIFICATION_ID, notificationId)
                 putExtra(DownloadConst.KEY_PROGRESS, currentProgress)
@@ -290,7 +305,12 @@ internal class DownloadNotificationManager(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
                     notificationConfig.smallIcon
                 )
+                putExtra(NotificationConst.CANCEL_BUTTON_TEXT, buttonTextConfig.cancel)
+                putExtra(NotificationConst.PAUSE_BUTTON_TEXT, buttonTextConfig.pause)
+                putExtra(NotificationConst.RESUME_BUTTON_TEXT, buttonTextConfig.resume)
+                putExtra(NotificationConst.RETRY_BUTTON_TEXT, buttonTextConfig.retry)
                 putExtra(DownloadConst.KEY_FILE_NAME, downloadTitles?.canceledTitle ?: fileName)
+                putExtra(DownloadConst.KEY_CONTENT_TEXT, downloadContentTexts?.canceledContentText)
                 putExtra(DownloadConst.KEY_REQUEST_ID, requestId)
                 putExtra(NotificationConst.KEY_NOTIFICATION_ID, notificationId)
                 action = NotificationConst.ACTION_DOWNLOAD_CANCELLED
@@ -322,7 +342,12 @@ internal class DownloadNotificationManager(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
                     notificationConfig.smallIcon
                 )
+                putExtra(NotificationConst.CANCEL_BUTTON_TEXT, buttonTextConfig.cancel)
+                putExtra(NotificationConst.PAUSE_BUTTON_TEXT, buttonTextConfig.pause)
+                putExtra(NotificationConst.RESUME_BUTTON_TEXT, buttonTextConfig.resume)
+                putExtra(NotificationConst.RETRY_BUTTON_TEXT, buttonTextConfig.retry)
                 putExtra(DownloadConst.KEY_FILE_NAME, downloadTitles?.pausedTitle ?: fileName)
+                putExtra(DownloadConst.KEY_CONTENT_TEXT, downloadContentTexts?.pausedContentText)
                 putExtra(DownloadConst.KEY_PROGRESS, currentProgress)
                 putExtra(DownloadConst.KEY_REQUEST_ID, requestId)
                 putExtra(NotificationConst.KEY_NOTIFICATION_ID, notificationId)

--- a/ketch/src/main/java/com/ketch/internal/notification/DownloadNotificationManager.kt
+++ b/ketch/src/main/java/com/ketch/internal/notification/DownloadNotificationManager.kt
@@ -12,6 +12,7 @@ import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.work.ForegroundInfo
 import com.ketch.NotificationConfig
+import com.ketch.internal.download.DownloadTitles
 import com.ketch.internal.utils.DownloadConst
 import com.ketch.internal.utils.NotificationConst
 import com.ketch.internal.utils.TextUtil
@@ -34,7 +35,8 @@ internal class DownloadNotificationManager(
     private val context: Context,
     private val notificationConfig: NotificationConfig,
     private val requestId: Int,
-    private val fileName: String
+    private val fileName: String,
+    private val downloadTitles: DownloadTitles?
 ) {
 
     private var foregroundInfo: ForegroundInfo? = null
@@ -140,7 +142,7 @@ internal class DownloadNotificationManager(
 
             var nb = notificationBuilder
                 .setSmallIcon(notificationConfig.smallIcon)
-                .setContentTitle("Downloading $fileName")
+                .setContentTitle(downloadTitles?.progressTitle ?: "Downloading $fileName")
                 .setContentIntent(pendingIntentOpen)
                 .setProgress(DownloadConst.MAX_VALUE_PROGRESS, progress, if (length == 0L) true else false)
                 .setOnlyAlertOnce(true)
@@ -223,7 +225,7 @@ internal class DownloadNotificationManager(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
                     notificationConfig.smallIcon
                 )
-                putExtra(DownloadConst.KEY_FILE_NAME, fileName)
+                putExtra(DownloadConst.KEY_FILE_NAME, downloadTitles?.successTitle ?: fileName)
                 putExtra(DownloadConst.KEY_LENGTH, totalLength)
                 putExtra(DownloadConst.KEY_REQUEST_ID, requestId)
                 putExtra(NotificationConst.KEY_NOTIFICATION_ID, notificationId)
@@ -256,7 +258,7 @@ internal class DownloadNotificationManager(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
                     notificationConfig.smallIcon
                 )
-                putExtra(DownloadConst.KEY_FILE_NAME, fileName)
+                putExtra(DownloadConst.KEY_FILE_NAME, downloadTitles?.failedTitle ?: fileName)
                 putExtra(DownloadConst.KEY_REQUEST_ID, requestId)
                 putExtra(NotificationConst.KEY_NOTIFICATION_ID, notificationId)
                 putExtra(DownloadConst.KEY_PROGRESS, currentProgress)
@@ -288,7 +290,7 @@ internal class DownloadNotificationManager(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
                     notificationConfig.smallIcon
                 )
-                putExtra(DownloadConst.KEY_FILE_NAME, fileName)
+                putExtra(DownloadConst.KEY_FILE_NAME, downloadTitles?.canceledTitle ?: fileName)
                 putExtra(DownloadConst.KEY_REQUEST_ID, requestId)
                 putExtra(NotificationConst.KEY_NOTIFICATION_ID, notificationId)
                 action = NotificationConst.ACTION_DOWNLOAD_CANCELLED
@@ -320,7 +322,7 @@ internal class DownloadNotificationManager(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
                     notificationConfig.smallIcon
                 )
-                putExtra(DownloadConst.KEY_FILE_NAME, fileName)
+                putExtra(DownloadConst.KEY_FILE_NAME, downloadTitles?.pausedTitle ?: fileName)
                 putExtra(DownloadConst.KEY_PROGRESS, currentProgress)
                 putExtra(DownloadConst.KEY_REQUEST_ID, requestId)
                 putExtra(NotificationConst.KEY_NOTIFICATION_ID, notificationId)

--- a/ketch/src/main/java/com/ketch/internal/notification/DownloadNotificationManager.kt
+++ b/ketch/src/main/java/com/ketch/internal/notification/DownloadNotificationManager.kt
@@ -145,7 +145,7 @@ internal class DownloadNotificationManager(
             )
 
             var nb = notificationBuilder
-                .setSmallIcon(notificationConfig.smallIcon)
+                .setSmallIcon(notificationConfig.smallIcons.progress)
                 .setContentTitle(downloadTitles?.progressTitle ?: "Downloading $fileName")
                 .setContentIntent(pendingIntentOpen)
                 .setProgress(DownloadConst.MAX_VALUE_PROGRESS, progress, if (length == 0L) true else false)
@@ -227,7 +227,7 @@ internal class DownloadNotificationManager(
                 )
                 putExtra(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
-                    notificationConfig.smallIcon
+                    notificationConfig.smallIcons.success
                 )
                 putExtra(NotificationConst.CANCEL_BUTTON_TEXT, buttonTextConfig.cancel)
                 putExtra(NotificationConst.PAUSE_BUTTON_TEXT, buttonTextConfig.pause)
@@ -267,7 +267,10 @@ internal class DownloadNotificationManager(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
                     notificationConfig.smallIcon
                 )
-
+                putExtra(
+                    NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
+                    notificationConfig.smallIcons.failed
+                )
                 putExtra(NotificationConst.CANCEL_BUTTON_TEXT, buttonTextConfig.cancel)
                 putExtra(NotificationConst.PAUSE_BUTTON_TEXT, buttonTextConfig.pause)
                 putExtra(NotificationConst.RESUME_BUTTON_TEXT, buttonTextConfig.resume)
@@ -303,7 +306,7 @@ internal class DownloadNotificationManager(
                 )
                 putExtra(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
-                    notificationConfig.smallIcon
+                    notificationConfig.smallIcons.cancelled
                 )
                 putExtra(NotificationConst.CANCEL_BUTTON_TEXT, buttonTextConfig.cancel)
                 putExtra(NotificationConst.PAUSE_BUTTON_TEXT, buttonTextConfig.pause)
@@ -340,7 +343,7 @@ internal class DownloadNotificationManager(
                 )
                 putExtra(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
-                    notificationConfig.smallIcon
+                    notificationConfig.smallIcons.paused
                 )
                 putExtra(NotificationConst.CANCEL_BUTTON_TEXT, buttonTextConfig.cancel)
                 putExtra(NotificationConst.PAUSE_BUTTON_TEXT, buttonTextConfig.pause)

--- a/ketch/src/main/java/com/ketch/internal/notification/DownloadNotificationManager.kt
+++ b/ketch/src/main/java/com/ketch/internal/notification/DownloadNotificationManager.kt
@@ -265,10 +265,6 @@ internal class DownloadNotificationManager(
                 )
                 putExtra(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
-                    notificationConfig.smallIcon
-                )
-                putExtra(
-                    NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
                     notificationConfig.smallIcons.failed
                 )
                 putExtra(NotificationConst.CANCEL_BUTTON_TEXT, buttonTextConfig.cancel)

--- a/ketch/src/main/java/com/ketch/internal/notification/NotificationReceiver.kt
+++ b/ketch/src/main/java/com/ketch/internal/notification/NotificationReceiver.kt
@@ -102,7 +102,12 @@ internal class NotificationReceiver : BroadcastReceiver() {
                 intent.extras?.getInt(NotificationConst.KEY_NOTIFICATION_SMALL_ICON)
                     ?: NotificationConst.DEFAULT_VALUE_NOTIFICATION_SMALL_ICON
             val fileName = intent.extras?.getString(DownloadConst.KEY_FILE_NAME) ?: ""
+            val contentText = intent.extras?.getString(DownloadConst.KEY_CONTENT_TEXT) ?: ""
             val currentProgress = intent.extras?.getInt(DownloadConst.KEY_PROGRESS) ?: 0
+            val cancelButtonText = intent.extras?.getString(NotificationConst.CANCEL_BUTTON_TEXT)
+            val pauseButtonText = intent.extras?.getString(NotificationConst.PAUSE_BUTTON_TEXT)
+            val resumeButtonText = intent.extras?.getString(NotificationConst.RESUME_BUTTON_TEXT)
+            val retryButtonText = intent.extras?.getString(NotificationConst.RETRY_BUTTON_TEXT)
             val requestId =
                 intent.extras?.getInt(DownloadConst.KEY_REQUEST_ID) ?: -1
             val totalLength = intent.extras?.getLong(DownloadConst.KEY_LENGTH)
@@ -175,17 +180,19 @@ internal class NotificationReceiver : BroadcastReceiver() {
                 NotificationCompat.Builder(context, NotificationConst.NOTIFICATION_CHANNEL_ID)
                     .setSmallIcon(notificationSmallIcon)
                     .setContentText(
-                        when (intent.action) {
-                            NotificationConst.ACTION_DOWNLOAD_COMPLETED ->
-                                "Download successful. (${
-                                    TextUtil.getTotalLengthText(
-                                        totalLength
-                                    )
-                                })"
+                        contentText.ifEmpty {
+                            when (intent.action) {
+                                NotificationConst.ACTION_DOWNLOAD_COMPLETED ->
+                                    "Download successful. (${
+                                        TextUtil.getTotalLengthText(
+                                            totalLength
+                                        )
+                                    })"
 
-                            NotificationConst.ACTION_DOWNLOAD_FAILED -> "Download failed."
-                            NotificationConst.ACTION_DOWNLOAD_PAUSED -> "Download paused."
-                            else -> "Download cancelled."
+                                NotificationConst.ACTION_DOWNLOAD_FAILED -> "Download failed."
+                                NotificationConst.ACTION_DOWNLOAD_PAUSED -> "Download paused."
+                                else -> "Download cancelled."
+                            }
                         }
                     )
                     .setContentTitle(fileName)
@@ -198,22 +205,22 @@ internal class NotificationReceiver : BroadcastReceiver() {
             if (intent.action == NotificationConst.ACTION_DOWNLOAD_FAILED) {
                 notificationBuilder = notificationBuilder.addAction(
                     -1,
-                    NotificationConst.RETRY_BUTTON_TEXT,
+                    retryButtonText,
                     pendingIntentRetry
                 )
                     .setProgress(DownloadConst.MAX_VALUE_PROGRESS, currentProgress, false)
-                    .addAction(-1, NotificationConst.CANCEL_BUTTON_TEXT, pendingIntentCancel)
+                    .addAction(-1, cancelButtonText, pendingIntentCancel)
                     .setSubText("$currentProgress%")
             }
             // add resume and cancel button for paused download
             if (intent.action == NotificationConst.ACTION_DOWNLOAD_PAUSED) {
                 notificationBuilder = notificationBuilder.addAction(
                     -1,
-                    NotificationConst.RESUME_BUTTON_TEXT,
+                    resumeButtonText,
                     pendingIntentResume
                 )
                     .setProgress(DownloadConst.MAX_VALUE_PROGRESS, currentProgress, false)
-                    .addAction(-1, NotificationConst.CANCEL_BUTTON_TEXT, pendingIntentCancel)
+                    .addAction(-1, cancelButtonText, pendingIntentCancel)
                     .setSubText("$currentProgress%")
             }
 

--- a/ketch/src/main/java/com/ketch/internal/utils/DownloadConst.kt
+++ b/ketch/src/main/java/com/ketch/internal/utils/DownloadConst.kt
@@ -8,6 +8,7 @@ internal object DownloadConst {
     const val KEY_FILE_NAME = "key_fileName"
     const val KEY_STATE = "key_state"
     const val KEY_PROGRESS = "key_progress"
+    const val KEY_CONTENT_TEXT = "key_content_text"
     const val MAX_VALUE_PROGRESS = 100
     const val PROGRESS = "progress"
     const val STARTED = "started"
@@ -16,6 +17,7 @@ internal object DownloadConst {
     const val KEY_REQUEST_ID = "key_request_id"
     const val KEY_DOWNLOAD_REQUEST = "key_download_request"
     const val KEY_NOTIFICATION_CONFIG = "key_notification_config"
+    const val KEY_BUTTON_TEXT_CONFIG = "key_button_text_config"
     const val ETAG_HEADER = "ETag"
     const val CONTENT_LENGTH = "Content-Length"
     const val RANGE_HEADER = "Range"

--- a/ketch/src/main/java/com/ketch/internal/utils/MapperUtil.kt
+++ b/ketch/src/main/java/com/ketch/internal/utils/MapperUtil.kt
@@ -1,7 +1,6 @@
 package com.ketch.internal.utils
 
 import com.ketch.DownloadModel
-import com.ketch.Status
 import com.ketch.internal.database.DownloadEntity
 
 // Mapper function to convert DownloadEntity to DownloadModel
@@ -14,7 +13,7 @@ internal fun DownloadEntity.toDownloadModel() =
         id = id,
         headers = WorkUtil.jsonToHashMap(headersJson),
         timeQueued = timeQueued,
-        status = Status.entries.find { it.name == status } ?: Status.DEFAULT,
+        status = status,
         total = totalBytes,
         progress = if (totalBytes.toInt() != 0) ((downloadedBytes * 100) / totalBytes).toInt() else 0,
         speedInBytePerMs = speedInBytePerMs,

--- a/ketch/src/main/java/com/ketch/internal/utils/TextUtil.kt
+++ b/ketch/src/main/java/com/ketch/internal/utils/TextUtil.kt
@@ -1,5 +1,7 @@
 package com.ketch.internal.utils
 
+import com.ketch.internal.download.DownloadProgressContentText
+
 internal object TextUtil {
 
     private const val MAX_PERCENT = 100
@@ -52,6 +54,72 @@ internal object TextUtil {
         }
 
         return "%.2f %s".format(value, units[unitIndex])
+    }
+
+    fun getTextFromCustomTemplate(
+        speedInBPerMs: Float,
+        progressPercent: Int,
+        lengthInBytes: Long,
+        template: DownloadProgressContentText
+    ): String {
+        val total = getTotalLengthText(lengthInBytes)
+        val speedText = getSpeedText(speedInBPerMs)
+        if (speedInBPerMs == 0F) return ""
+        val speedInBPerSecond = speedInBPerMs * SEC_IN_MILLIS
+        val bytesLeft = (lengthInBytes * (MAX_PERCENT - progressPercent) / MAX_PERCENT).toFloat()
+
+        val secondsLeft = bytesLeft / speedInBPerSecond
+        val minutesLeft = secondsLeft / VALUE_60
+        val hoursLeft = minutesLeft / VALUE_60
+
+        val values = mutableMapOf<String, Any>()
+        values["total"] = total
+        values["speed"] = speedText
+
+        return when {
+            secondsLeft < VALUE_60 -> {
+                values["second"] = secondsLeft
+                formatPluralTemplate(template.onlySeconds, values)
+            }
+
+            minutesLeft < VALUE_3 -> {
+                values["minute"] = minutesLeft
+                values["second"] = secondsLeft % VALUE_60
+                formatPluralTemplate(template.minutesAndSeconds, values)
+            }
+
+            minutesLeft < VALUE_60 -> {
+                values["minute"] = minutesLeft
+                formatPluralTemplate(template.onlyMinutes, values)
+            }
+
+            minutesLeft < VALUE_300 -> {
+                values["hour"] = hoursLeft
+                values["minute"] = minutesLeft % VALUE_60
+                formatPluralTemplate(template.hoursAndMinutes, values)
+            }
+
+            else -> {
+                values["hour"] = hoursLeft
+                formatPluralTemplate(template.onlyHours, values)
+            }
+        }
+
+    }
+
+    private fun formatPluralTemplate(template: String, values: Map<String, Any>): String {
+        return template.replace(Regex("\\[\\[#(\\w+)\\|([^|]+)\\|([^|]+)]]")) { matchResult ->
+            val key = matchResult.groupValues[1]
+            val singular = matchResult.groupValues[2]
+            val plural = matchResult.groupValues[3]
+
+
+            val value = if (listOf("hour", "minute", "second").contains(key)) {
+                if (values[key].toString().isNotEmpty()) "%.0f".format(values[key]) else 0
+            } else values[key].toString()
+
+            if (value == "1") singular.format(value) else plural.format(value)
+        }.trim()
     }
 
 }

--- a/ketch/src/main/java/com/ketch/internal/utils/TextUtil.kt
+++ b/ketch/src/main/java/com/ketch/internal/utils/TextUtil.kt
@@ -30,7 +30,7 @@ internal object TextUtil {
 
     fun getSpeedText(speedInBPerMs: Float): String {
         var value = speedInBPerMs * SEC_IN_MILLIS
-        val units = arrayOf("b/s", "kb/s", "mb/s", "gb/s")
+        val units = arrayOf("B/s", "KB/s", "MB/s", "GB/s")
         var unitIndex = 0
 
         while (value >= VALUE_500 && unitIndex < units.size - 1) {
@@ -43,7 +43,7 @@ internal object TextUtil {
 
     fun getTotalLengthText(lengthInBytes: Long): String {
         var value = lengthInBytes.toFloat()
-        val units = arrayOf("b", "kb", "mb", "gb")
+        val units = arrayOf("B", "KB", "MB", "GB")
         var unitIndex = 0
 
         while (value >= VALUE_500 && unitIndex < units.size - 1) {

--- a/ketch/src/main/java/com/ketch/internal/utils/WorkUtil.kt
+++ b/ketch/src/main/java/com/ketch/internal/utils/WorkUtil.kt
@@ -2,6 +2,7 @@ package com.ketch.internal.utils
 
 import android.content.Context
 import androidx.core.app.NotificationManagerCompat
+import com.ketch.ButtonTextConfig
 import com.ketch.NotificationConfig
 import com.ketch.internal.download.DownloadRequest
 import kotlinx.serialization.encodeToString
@@ -21,9 +22,20 @@ internal object WorkUtil {
         return Json.encodeToString(this)
     }
 
+    fun ButtonTextConfig.toJson(): String {
+        return Json.encodeToString(this)
+    }
+
     fun jsonToNotificationConfig(jsonStr: String): NotificationConfig {
         if (jsonStr.isEmpty()) {
             return NotificationConfig(smallIcon = NotificationConst.DEFAULT_VALUE_NOTIFICATION_SMALL_ICON)
+        }
+        return Json.decodeFromString(jsonStr)
+    }
+
+    fun jsonToButtonTextConfig(jsonStr: String): ButtonTextConfig {
+        if (jsonStr.isEmpty()) {
+            return ButtonTextConfig()
         }
         return Json.decodeFromString(jsonStr)
     }

--- a/ketch/src/main/java/com/ketch/internal/utils/WorkUtil.kt
+++ b/ketch/src/main/java/com/ketch/internal/utils/WorkUtil.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import androidx.core.app.NotificationManagerCompat
 import com.ketch.ButtonTextConfig
 import com.ketch.NotificationConfig
+import com.ketch.internal.download.DownloadContentTexts
 import com.ketch.internal.download.DownloadRequest
+import com.ketch.internal.download.DownloadTitles
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
@@ -38,6 +40,28 @@ internal object WorkUtil {
             return ButtonTextConfig()
         }
         return Json.decodeFromString(jsonStr)
+    }
+
+    fun jsonToDownloadTitles(jsonStr: String): DownloadTitles {
+        if (jsonStr.isEmpty()) {
+            return DownloadTitles()
+        }
+        return Json.decodeFromString(jsonStr)
+    }
+
+    fun DownloadTitles.toJson(): String {
+        return Json.encodeToString(this)
+    }
+
+    fun jsonToDownloadContentTexts(jsonStr: String): DownloadContentTexts {
+        if (jsonStr.isEmpty()) {
+            return DownloadContentTexts()
+        }
+        return Json.decodeFromString(jsonStr)
+    }
+
+    fun DownloadContentTexts.toJson(): String {
+        return Json.encodeToString(this)
     }
 
     fun hashMapToJson(headers: HashMap<String, String>): String {

--- a/ketch/src/main/java/com/ketch/internal/worker/DownloadWorker.kt
+++ b/ketch/src/main/java/com/ketch/internal/worker/DownloadWorker.kt
@@ -53,7 +53,6 @@ internal class DownloadWorker(
         val dirPath = downloadRequest.path
         val fileName = downloadRequest.fileName
         val headers = downloadRequest.headers
-        val supportPauseResume = downloadRequest.supportPauseResume // in case of false, we will not store total length info in DB
 
         if (notificationConfig.enabled) {
             downloadNotificationManager = DownloadNotificationManager(
@@ -94,7 +93,6 @@ internal class DownloadWorker(
                 url = url,
                 path = dirPath,
                 fileName = fileName,
-                supportPauseResume = supportPauseResume,
                 downloadService = downloadService
             ).download(
                 headers = headers,

--- a/ketch/src/main/java/com/ketch/internal/worker/DownloadWorker.kt
+++ b/ketch/src/main/java/com/ketch/internal/worker/DownloadWorker.kt
@@ -54,13 +54,15 @@ internal class DownloadWorker(
         val fileName = downloadRequest.fileName
         val headers = downloadRequest.headers
         val supportPauseResume = downloadRequest.supportPauseResume // in case of false, we will not store total length info in DB
+        val downloadTitles = downloadRequest.downloadTitles
 
         if (notificationConfig.enabled) {
             downloadNotificationManager = DownloadNotificationManager(
                 context = context,
                 notificationConfig = notificationConfig,
                 requestId = id,
-                fileName = fileName
+                fileName = fileName,
+                downloadTitles = downloadTitles
             )
         }
 

--- a/ketch/src/main/java/com/ketch/internal/worker/DownloadWorker.kt
+++ b/ketch/src/main/java/com/ketch/internal/worker/DownloadWorker.kt
@@ -57,8 +57,7 @@ internal class DownloadWorker(
         val dirPath = downloadRequest.path
         val fileName = downloadRequest.fileName
         val headers = downloadRequest.headers
-        val supportPauseResume =
-            downloadRequest.supportPauseResume // in case of false, we will not store total length info in DB
+        val supportPauseResume = downloadRequest.supportPauseResume // in case of false, we will not store total length info in DB
         val downloadTitles = downloadRequest.downloadTitles
         val downloadContentText = downloadRequest.downloadContentTexts
 

--- a/ketch/src/main/java/com/ketch/internal/worker/DownloadWorker.kt
+++ b/ketch/src/main/java/com/ketch/internal/worker/DownloadWorker.kt
@@ -48,21 +48,29 @@ internal class DownloadWorker(
                 inputData.getString(DownloadConst.KEY_NOTIFICATION_CONFIG) ?: ""
             )
 
+        val buttonTextConfig = WorkUtil.jsonToButtonTextConfig(
+            inputData.getString(DownloadConst.KEY_BUTTON_TEXT_CONFIG) ?: ""
+        )
+
         val id = downloadRequest.id
         val url = downloadRequest.url
         val dirPath = downloadRequest.path
         val fileName = downloadRequest.fileName
         val headers = downloadRequest.headers
-        val supportPauseResume = downloadRequest.supportPauseResume // in case of false, we will not store total length info in DB
+        val supportPauseResume =
+            downloadRequest.supportPauseResume // in case of false, we will not store total length info in DB
         val downloadTitles = downloadRequest.downloadTitles
+        val downloadContentText = downloadRequest.downloadContentTexts
 
         if (notificationConfig.enabled) {
             downloadNotificationManager = DownloadNotificationManager(
                 context = context,
                 notificationConfig = notificationConfig,
+                buttonTextConfig = buttonTextConfig,
                 requestId = id,
                 fileName = fileName,
-                downloadTitles = downloadTitles
+                downloadTitles = downloadTitles,
+                downloadContentTexts = downloadContentText
             )
         }
 

--- a/ketch/src/main/java/com/ketch/internal/worker/DownloadWorker.kt
+++ b/ketch/src/main/java/com/ketch/internal/worker/DownloadWorker.kt
@@ -6,8 +6,8 @@ import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import com.ketch.Status
 import com.ketch.internal.database.DatabaseInstance
-import com.ketch.internal.download.DownloadTask
 import com.ketch.internal.download.ApiResponseHeaderChecker
+import com.ketch.internal.download.DownloadTask
 import com.ketch.internal.network.RetrofitInstance
 import com.ketch.internal.notification.DownloadNotificationManager
 import com.ketch.internal.utils.DownloadConst
@@ -102,7 +102,7 @@ internal class DownloadWorker(
 
                     downloadDao.find(id)?.copy(
                         totalBytes = length,
-                        status = Status.STARTED.toString(),
+                        status = Status.STARTED,
                         lastModified = System.currentTimeMillis()
                     )?.let { downloadDao.update(it) }
 
@@ -127,7 +127,7 @@ internal class DownloadWorker(
                         downloadDao.find(id)?.copy(
                             downloadedBytes = downloadedBytes,
                             speedInBytePerMs = speed,
-                            status = Status.PROGRESS.toString(),
+                            status = Status.PROGRESS,
                             lastModified = System.currentTimeMillis()
                         )?.let { downloadDao.update(it) }
 
@@ -154,7 +154,7 @@ internal class DownloadWorker(
 
             downloadDao.find(id)?.copy(
                 totalBytes = totalLength,
-                status = Status.SUCCESS.toString(),
+                status = Status.SUCCESS,
                 lastModified = System.currentTimeMillis()
             )?.let { downloadDao.update(it) }
 
@@ -165,10 +165,10 @@ internal class DownloadWorker(
         } catch (e: Exception) {
             GlobalScope.launch {
                 if (e is CancellationException) {
-                    if (downloadDao.find(id)?.userAction == UserAction.PAUSE.toString()) {
+                    if (downloadDao.find(id)?.userAction == UserAction.PAUSE) {
 
                         downloadDao.find(id)?.copy(
-                            status = Status.PAUSED.toString(),
+                            status = Status.PAUSED,
                             lastModified = System.currentTimeMillis()
                         )?.let { downloadDao.update(it) }
                         val downloadEntity = downloadDao.find(id)
@@ -186,7 +186,7 @@ internal class DownloadWorker(
                     } else {
 
                         downloadDao.find(id)?.copy(
-                            status = Status.CANCELLED.toString(),
+                            status = Status.CANCELLED,
                             lastModified = System.currentTimeMillis()
                         )?.let { downloadDao.update(it) }
                         FileUtil.deleteFileIfExists(dirPath, fileName)
@@ -196,7 +196,7 @@ internal class DownloadWorker(
                 } else {
 
                     downloadDao.find(id)?.copy(
-                        status = Status.FAILED.toString(),
+                        status = Status.FAILED,
                         failureReason = e.message ?: "",
                         lastModified = System.currentTimeMillis()
                     )?.let { downloadDao.update(it) }


### PR DESCRIPTION
- The changes do not change the original logic at all and are fully compatible (New options are completely optional)
- Added ability to change titles for download statuses (downloading, successful, failed,...), as well as content text. It is also possible to customize how download progress is displayed
- Buttons (Cancel, resume,...) on notifications are customizable (better multilingual support)
- Change the display unit to Megabyte instead of Megabit (original code is calculating Megabyte but is displaying as Megabit)

![Screenshot_2025 03 23_06 19 00](https://github.com/user-attachments/assets/b1bca8aa-2c91-46e1-8833-d1d20d35e0dc) 
