### PR TITLE
Add ability to customize download title, content text, button text

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,11 +155,20 @@ dependencies {
      ketch = Ketch.builder().setNotificationConfig(
               config = NotificationConfig(
                 enabled = true,
-                smallIcon = R.drawable.ic_launcher_foreground // It is required to pass the smallIcon for notification.
+                smallIcon = R.drawable.ic_launcher_foreground, // It is required to pass the smallIcon for notification.
+                smallIcons = NotificationSmallIconConfig(
+                  progress = android.R.drawable.stat_sys_download,
+                  success = android.R.drawable.checkbox_on_background,
+                  failed = android.R.drawable.stat_notify_error,
+                  paused = android.R.drawable.ic_media_pause,
+                  cancelled = android.R.drawable.ic_notification_clear_all
+                ) //Default: smallIcon, pass the smallIcon for notification status
               )
             ).build(this)
      ```
+
      
+    
 ## Customisation
   
 - Provide headers with network request.
@@ -177,6 +186,55 @@ dependencies {
    tag = tag, //Default: null
   )
   ```
+
+- Download title: Customize the title on the notification for the statuses
+
+  ```Kotlin
+  ketch.download(url, fileName, path,
+    downloadTitles = DownloadTitles(
+        progressTitle = "Downloading",
+        failedTitle = "Failed",
+        successTitle = "Success",
+        canceledTitle = "Cancelled",
+        pausedTitle = "Paused"
+    ) //Default: Downloading <file name>
+  )
+  ```
+
+- Download title: Customize the context text on the notification for the statuses
+
+  ```Kotlin
+  ketch.download(url, fileName, path,
+    downloadContentTexts = DownloadContentTexts(
+      successContentText = "Success content",
+      failedContentText = "Failed content",
+      canceledContentText = "Cancelled content ",
+      pausedContentText = "Paused content",
+      progressContentText = DownloadProgressContentText()
+    ), //Default: Default download states, and default progress states in NotificationConfig
+  )
+  ```
+  - Customize download progress status (this will not depend on NotificationConfig)
+  
+    ```Kotlin
+    DownloadProgressContentText(
+      onlySeconds = "Left [[#second|%s second|%s seconds]] - total [[#total|%s|%s]] - speed [[#speed|%s|%s]]",
+      onlyMinutes = "शेष [[#minute|%s मिनट|%s मिनट]]",
+      onlyHours = "Còn lại [[#hour|%s giờ|%s giờ]]",
+      minutesAndSeconds = "Left [[#minute|%s minute|%s minutes]] [[#second|%s second|%s seconds]]",
+      hoursAndMinutes = "Left [[#hour|%s hour|%s hours]] [[#minute|%s minute|%s minutes]]",
+    )
+
+    // Template usage:
+   
+    // #second, #minute, #hour: Time variable
+    // #total: Total download file size variable
+    // #speed: Download speed variable
+    // %s: Plural template (always %s)
+
+    // Syntax: <variable>|%s<text singular time>|%s<plural time text> inside the pair [[ ]]
+    // with #speed and #total just have text in <plural time text>
+    ```
   
 - Download config: Provides custom connect and read timeout
 
@@ -216,6 +274,20 @@ dependencies {
         showTime = true //Default: true
       )
     ).build(this)
+  ```
+
+       
+- Notification config: To customize the text button on the notification       
+     
+  ```Kotlin
+  ketch = Ketch.builder().setButtonTextConfig(
+            ButtonTextConfig(
+                cancel = "Cancel",
+                pause = "Pause",
+                resume = "Resume",
+                retry = "Retry"
+            ) //Default: Default value same as above example
+        ).build(this)
   ```
 
 # Blog

--- a/app/src/main/java/com/khush/sample/MainApplication.kt
+++ b/app/src/main/java/com/khush/sample/MainApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import com.ketch.DownloadConfig
 import com.ketch.Ketch
 import com.ketch.NotificationConfig
+import com.ketch.NotificationSmallIconConfig
 
 class MainApplication : Application() {
 
@@ -16,7 +17,14 @@ class MainApplication : Application() {
             .setNotificationConfig(
                 NotificationConfig(
                     true,
-                    smallIcon = R.drawable.ic_launcher_foreground
+                    smallIcon = R.drawable.ic_launcher_foreground,
+                    smallIcons = NotificationSmallIconConfig(
+                        progress = android.R.drawable.stat_sys_download,
+                        success = android.R.drawable.checkbox_on_background,
+                        failed = android.R.drawable.stat_notify_error,
+                        paused = android.R.drawable.ic_media_pause,
+                        cancelled = android.R.drawable.ic_notification_clear_all
+                    )
                 )
             )
             .enableLogs(true)

--- a/app/src/main/java/com/khush/sample/MainFragment.kt
+++ b/app/src/main/java/com/khush/sample/MainFragment.kt
@@ -22,10 +22,14 @@ import androidx.recyclerview.widget.SimpleItemAnimator
 import com.ketch.DownloadModel
 import com.ketch.Ketch
 import com.ketch.Status
+import com.ketch.internal.download.DownloadContentTexts
+import com.ketch.internal.download.DownloadProgressContentText
+import com.ketch.internal.download.DownloadTitles
 import com.khush.sample.databinding.FragmentMainBinding
 import com.khush.sample.databinding.ItemFileBinding
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import java.io.File
 
@@ -142,7 +146,27 @@ class MainFragment : Fragment() {
                 path = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).path,
                 fileName = "Sample_Video_1.mp4",
                 tag = "Video",
-                metaData = "158"
+                metaData = "158",
+                downloadTitles = DownloadTitles(
+                    progressTitle = "Downloading",
+                    failedTitle = "Failed",
+                    successTitle = "Success",
+                    canceledTitle = "Cancelled",
+                    pausedTitle = "Paused"
+                ),
+                downloadContentTexts = DownloadContentTexts(
+                    successContentText = "Success content",
+                    failedContentText = "Failed content",
+                    canceledContentText = "Cancelled content ",
+                    pausedContentText = "Paused content",
+                    progressContentText = DownloadProgressContentText(
+                        onlySeconds = "Left [[#second|%s second|%s seconds]] - total [[#total|%s|%s]] - speed [[#speed|%s|%s]]",
+                        onlyMinutes = "शेष [[#minute|%s मिनट|%s मिनट]]",
+                        onlyHours = "Còn lại [[#hour|%s giờ|%s giờ]]",
+                        minutesAndSeconds = "Left [[#minute|%s minute|%s minutes]] [[#second|%s second|%s seconds]]",
+                        hoursAndMinutes = "Left [[#hour|%s hour|%s hours]] [[#minute|%s minute|%s minutes]]",
+                    )
+                ),
             )
         }
 

--- a/app/src/main/java/com/khush/sample/MainFragment.kt
+++ b/app/src/main/java/com/khush/sample/MainFragment.kt
@@ -139,7 +139,7 @@ class MainFragment : Fragment() {
             )
         )
 
-        fragmentMainBinding.bt1.text = "Video 1"
+        fragmentMainBinding.bt1.text = "Video 1 (with custom title)"
         fragmentMainBinding.bt1.setOnClickListener {
             ketch.download(
                 url = "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",

--- a/app/src/main/java/com/khush/sample/Util.kt
+++ b/app/src/main/java/com/khush/sample/Util.kt
@@ -42,7 +42,7 @@ object Util {
 
     private fun getSpeedText(speedInBPerMs: Float): String {
         var value = speedInBPerMs * SEC_IN_MILLIS
-        val units = arrayOf("b/s", "kb/s", "mb/s", "gb/s")
+        val units = arrayOf("B/s", "KB/s", "MB/s", "GB/s")
         var unitIndex = 0
 
         while (value >= VALUE_500 && unitIndex < units.size - 1) {
@@ -55,7 +55,7 @@ object Util {
 
     fun getTotalLengthText(lengthInBytes: Long): String {
         var value = lengthInBytes.toFloat()
-        val units = arrayOf("b", "kb", "mb", "gb")
+        val units = arrayOf("B", "KB", "MB", "GB")
         var unitIndex = 0
 
         while (value >= VALUE_500 && unitIndex < units.size - 1) {

--- a/ketch/src/main/java/com/ketch/ButtonTextConfig.kt
+++ b/ketch/src/main/java/com/ketch/ButtonTextConfig.kt
@@ -1,0 +1,12 @@
+package com.ketch
+
+import com.ketch.internal.utils.NotificationConst
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ButtonTextConfig(
+    val cancel: String = NotificationConst.CANCEL_BUTTON_TEXT,
+    val pause: String = NotificationConst.PAUSE_BUTTON_TEXT,
+    val resume: String = NotificationConst.RESUME_BUTTON_TEXT,
+    val retry: String = NotificationConst.RETRY_BUTTON_TEXT
+)

--- a/ketch/src/main/java/com/ketch/Ketch.kt
+++ b/ketch/src/main/java/com/ketch/Ketch.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.work.WorkManager
 import com.ketch.internal.database.DatabaseInstance
 import com.ketch.internal.download.ApiResponseHeaderChecker
+import com.ketch.internal.download.DownloadContentTexts
 import com.ketch.internal.download.DownloadManager
 import com.ketch.internal.download.DownloadRequest
 import com.ketch.internal.download.DownloadTitles
@@ -89,6 +90,7 @@ class Ketch private constructor(
     private val context: Context,
     private var downloadConfig: DownloadConfig,
     private var notificationConfig: NotificationConfig,
+    private var buttonTextConfig: ButtonTextConfig,
     private var logger: Logger,
     private var okHttpClient: OkHttpClient
 ) {
@@ -107,6 +109,7 @@ class Ketch private constructor(
             private var notificationConfig: NotificationConfig = NotificationConfig(
                 smallIcon = NotificationConst.DEFAULT_VALUE_NOTIFICATION_SMALL_ICON
             )
+            private var buttonTextConfig: ButtonTextConfig = ButtonTextConfig()
             private var logger: Logger = DownloadLogger(false)
             private lateinit var okHttpClient: OkHttpClient
 
@@ -122,6 +125,10 @@ class Ketch private constructor(
 
             fun setNotificationConfig(config: NotificationConfig) = apply {
                 this.notificationConfig = config
+            }
+
+            fun setButtonTextConfig(config: ButtonTextConfig) = apply {
+                this.buttonTextConfig = config
             }
 
             fun enableLogs(enable: Boolean) = apply {
@@ -152,6 +159,7 @@ class Ketch private constructor(
                         context = context.applicationContext,
                         downloadConfig = downloadConfig,
                         notificationConfig = notificationConfig,
+                        buttonTextConfig = buttonTextConfig,
                         logger = logger,
                         okHttpClient = okHttpClient
                     )
@@ -171,6 +179,7 @@ class Ketch private constructor(
         workManager = WorkManager.getInstance(context.applicationContext),
         downloadConfig = downloadConfig,
         notificationConfig = notificationConfig,
+        buttonTextConfig = buttonTextConfig,
         logger = logger
     )
 
@@ -194,7 +203,8 @@ class Ketch private constructor(
         metaData: String = "",
         headers: HashMap<String, String> = hashMapOf(),
         supportPauseResume: Boolean = true,
-        downloadTitles: DownloadTitles? = null
+        downloadTitles: DownloadTitles? = null,
+        downloadContentTexts: DownloadContentTexts? = null
     ): Int {
         val downloadRequest = prepareDownloadRequest(
             url = url,
@@ -204,7 +214,8 @@ class Ketch private constructor(
             headers = headers,
             metaData = metaData,
             supportPauseResume = supportPauseResume,
-            downloadTitles = downloadTitles
+            downloadTitles = downloadTitles,
+            downloadContentTexts = downloadContentTexts
         )
         downloadManager.downloadAsync(downloadRequest)
         return downloadRequest.id
@@ -229,7 +240,8 @@ class Ketch private constructor(
         metaData: String = "",
         headers: HashMap<String, String> = hashMapOf(),
         supportPauseResume: Boolean = true,
-        downloadTitles: DownloadTitles? = null
+        downloadTitles: DownloadTitles? = null,
+        downloadContentTexts: DownloadContentTexts? = null
     ): Int {
         val downloadRequest = mutex.withLock {
             prepareDownloadRequest(
@@ -240,7 +252,8 @@ class Ketch private constructor(
                 headers = headers,
                 metaData = metaData,
                 supportPauseResume = supportPauseResume,
-                downloadTitles = downloadTitles
+                downloadTitles = downloadTitles,
+                downloadContentTexts = downloadContentTexts
             )
         }
         downloadManager.download(downloadRequest)
@@ -556,7 +569,8 @@ class Ketch private constructor(
         headers: HashMap<String, String>,
         metaData: String,
         supportPauseResume: Boolean,
-        downloadTitles: DownloadTitles?
+        downloadTitles: DownloadTitles?,
+        downloadContentTexts: DownloadContentTexts?
     ): DownloadRequest {
         require(url.isNotEmpty() && path.isNotEmpty() && fileName.isNotEmpty()) {
             "Missing ${if (url.isEmpty()) "url" else if (path.isEmpty()) "path" else "fileName"}"
@@ -575,7 +589,8 @@ class Ketch private constructor(
             headers = headers,
             metaData = metaData,
             supportPauseResume = supportPauseResume,
-            downloadTitles = downloadTitles
+            downloadTitles = downloadTitles,
+            downloadContentTexts = downloadContentTexts
         )
 
         return downloadRequest

--- a/ketch/src/main/java/com/ketch/Ketch.kt
+++ b/ketch/src/main/java/com/ketch/Ketch.kt
@@ -6,6 +6,7 @@ import com.ketch.internal.database.DatabaseInstance
 import com.ketch.internal.download.ApiResponseHeaderChecker
 import com.ketch.internal.download.DownloadManager
 import com.ketch.internal.download.DownloadRequest
+import com.ketch.internal.download.DownloadTitles
 import com.ketch.internal.network.RetrofitInstance
 import com.ketch.internal.utils.DownloadConst
 import com.ketch.internal.utils.DownloadLogger
@@ -193,6 +194,7 @@ class Ketch private constructor(
         metaData: String = "",
         headers: HashMap<String, String> = hashMapOf(),
         supportPauseResume: Boolean = true,
+        downloadTitles: DownloadTitles? = null
     ): Int {
         val downloadRequest = prepareDownloadRequest(
             url = url,
@@ -202,6 +204,7 @@ class Ketch private constructor(
             headers = headers,
             metaData = metaData,
             supportPauseResume = supportPauseResume,
+            downloadTitles = downloadTitles
         )
         downloadManager.downloadAsync(downloadRequest)
         return downloadRequest.id
@@ -226,6 +229,7 @@ class Ketch private constructor(
         metaData: String = "",
         headers: HashMap<String, String> = hashMapOf(),
         supportPauseResume: Boolean = true,
+        downloadTitles: DownloadTitles? = null
     ): Int {
         val downloadRequest = mutex.withLock {
             prepareDownloadRequest(
@@ -236,6 +240,7 @@ class Ketch private constructor(
                 headers = headers,
                 metaData = metaData,
                 supportPauseResume = supportPauseResume,
+                downloadTitles = downloadTitles
             )
         }
         downloadManager.download(downloadRequest)
@@ -551,6 +556,7 @@ class Ketch private constructor(
         headers: HashMap<String, String>,
         metaData: String,
         supportPauseResume: Boolean,
+        downloadTitles: DownloadTitles?
     ): DownloadRequest {
         require(url.isNotEmpty() && path.isNotEmpty() && fileName.isNotEmpty()) {
             "Missing ${if (url.isEmpty()) "url" else if (path.isEmpty()) "path" else "fileName"}"
@@ -569,6 +575,7 @@ class Ketch private constructor(
             headers = headers,
             metaData = metaData,
             supportPauseResume = supportPauseResume,
+            downloadTitles = downloadTitles
         )
 
         return downloadRequest

--- a/ketch/src/main/java/com/ketch/NotificationConfig.kt
+++ b/ketch/src/main/java/com/ketch/NotificationConfig.kt
@@ -12,5 +12,21 @@ data class NotificationConfig(
     val showSpeed: Boolean = true,
     val showSize: Boolean = true,
     val showTime: Boolean = true,
-    val smallIcon: Int
+    val smallIcon: Int,
+    val smallIcons: NotificationSmallIconConfig = NotificationSmallIconConfig(
+        progress = smallIcon,
+        success = smallIcon,
+        failed = smallIcon,
+        paused = smallIcon,
+        cancelled = smallIcon
+    )
+)
+
+@Serializable
+data class NotificationSmallIconConfig(
+    val progress: Int,
+    val success: Int,
+    val failed: Int,
+    val paused: Int,
+    val cancelled: Int
 )

--- a/ketch/src/main/java/com/ketch/internal/database/DownloadDatabase.kt
+++ b/ketch/src/main/java/com/ketch/internal/database/DownloadDatabase.kt
@@ -3,7 +3,7 @@ package com.ketch.internal.database
 import androidx.room.Database
 import androidx.room.RoomDatabase
 
-@Database(entities = [DownloadEntity::class], version = 1)
+@Database(entities = [DownloadEntity::class], version = 2)
 internal abstract class DownloadDatabase : RoomDatabase() {
     abstract fun downloadDao(): DownloadDao
 }

--- a/ketch/src/main/java/com/ketch/internal/database/DownloadEntity.kt
+++ b/ketch/src/main/java/com/ketch/internal/database/DownloadEntity.kt
@@ -3,6 +3,7 @@ package com.ketch.internal.database
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.ketch.Status
+import com.ketch.internal.download.DownloadProgressContentText
 import com.ketch.internal.utils.UserAction
 
 @Entity(
@@ -18,12 +19,15 @@ internal data class DownloadEntity(
     var successTitle: String = "",
     var canceledTitle: String = "",
     var pausedTitle: String = "",
-
-    var progressContentText: String= "",
-    val failedContentText: String= "",
-    val successContentText: String= "",
-    val canceledContentText: String= "",
-    val pausedContentText: String= "",
+    val progressContentTextOnlySeconds: String,
+    val progressContentTextOnlyMinutes: String,
+    val progressContentTextOnlyHours: String,
+    val progressContentTextMinutesAndSeconds: String,
+    val progressContentTextHoursAndMinutes: String,
+    val failedContentText: String = "",
+    val successContentText: String = "",
+    val canceledContentText: String = "",
+    val pausedContentText: String = "",
 
     @PrimaryKey
     var id: Int = 0,

--- a/ketch/src/main/java/com/ketch/internal/database/DownloadEntity.kt
+++ b/ketch/src/main/java/com/ketch/internal/database/DownloadEntity.kt
@@ -13,6 +13,11 @@ internal data class DownloadEntity(
     var path: String = "",
     var fileName: String = "",
     var tag: String = "",
+    var progressTitle: String = "",
+    var failedTitle: String = "",
+    var successTitle: String = "",
+    var canceledTitle: String = "",
+    var pausedTitle: String = "",
     @PrimaryKey
     var id: Int = 0,
     var headersJson: String = "",

--- a/ketch/src/main/java/com/ketch/internal/database/DownloadEntity.kt
+++ b/ketch/src/main/java/com/ketch/internal/database/DownloadEntity.kt
@@ -18,6 +18,13 @@ internal data class DownloadEntity(
     var successTitle: String = "",
     var canceledTitle: String = "",
     var pausedTitle: String = "",
+
+    var progressContentText: String= "",
+    val failedContentText: String= "",
+    val successContentText: String= "",
+    val canceledContentText: String= "",
+    val pausedContentText: String= "",
+
     @PrimaryKey
     var id: Int = 0,
     var headersJson: String = "",

--- a/ketch/src/main/java/com/ketch/internal/database/DownloadEntity.kt
+++ b/ketch/src/main/java/com/ketch/internal/database/DownloadEntity.kt
@@ -3,7 +3,6 @@ package com.ketch.internal.database
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.ketch.Status
-import com.ketch.internal.download.DownloadProgressContentText
 import com.ketch.internal.utils.UserAction
 
 @Entity(
@@ -14,20 +13,8 @@ internal data class DownloadEntity(
     var path: String = "",
     var fileName: String = "",
     var tag: String = "",
-    var progressTitle: String = "",
-    var failedTitle: String = "",
-    var successTitle: String = "",
-    var canceledTitle: String = "",
-    var pausedTitle: String = "",
-    val progressContentTextOnlySeconds: String,
-    val progressContentTextOnlyMinutes: String,
-    val progressContentTextOnlyHours: String,
-    val progressContentTextMinutesAndSeconds: String,
-    val progressContentTextHoursAndMinutes: String,
-    val failedContentText: String = "",
-    val successContentText: String = "",
-    val canceledContentText: String = "",
-    val pausedContentText: String = "",
+    val downloadTitles: String = "",
+    val downloadContentTexts: String = "",
 
     @PrimaryKey
     var id: Int = 0,

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadManager.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadManager.kt
@@ -7,6 +7,7 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
+import com.ketch.ButtonTextConfig
 import com.ketch.DownloadConfig
 import com.ketch.DownloadModel
 import com.ketch.Logger
@@ -41,6 +42,7 @@ internal class DownloadManager(
     private val workManager: WorkManager,
     private val downloadConfig: DownloadConfig,
     private val notificationConfig: NotificationConfig,
+    private val buttonTextConfig: ButtonTextConfig,
     private val logger: Logger
 ) {
 
@@ -138,6 +140,7 @@ internal class DownloadManager(
         val inputDataBuilder = Data.Builder()
             .putString(DownloadConst.KEY_DOWNLOAD_REQUEST, downloadRequest.toJson())
             .putString(DownloadConst.KEY_NOTIFICATION_CONFIG, notificationConfig.toJson())
+            .putString(DownloadConst.KEY_BUTTON_TEXT_CONFIG, buttonTextConfig.toJson())
 
         val inputData = inputDataBuilder.build()
 
@@ -190,7 +193,20 @@ internal class DownloadManager(
                     uuid = downloadWorkRequest.id.toString(),
                     lastModified = System.currentTimeMillis(),
                     userAction = UserAction.START.toString(),
-                    metaData = downloadRequest.metaData
+                    metaData = downloadRequest.metaData,
+                    progressTitle = downloadRequest.downloadTitles?.progressTitle ?: "",
+                    failedTitle = downloadRequest.downloadTitles?.failedTitle ?: "",
+                    successTitle = downloadRequest.downloadTitles?.successTitle ?: "",
+                    canceledTitle = downloadRequest.downloadTitles?.canceledTitle ?: "",
+                    pausedTitle = downloadRequest.downloadTitles?.pausedTitle ?: "",
+                    failedContentText = downloadRequest.downloadContentTexts?.failedContentText
+                        ?: "",
+                    successContentText = downloadRequest.downloadContentTexts?.successContentText
+                        ?: "",
+                    canceledContentText = downloadRequest.downloadContentTexts?.canceledContentText
+                        ?: "",
+                    pausedContentText = downloadRequest.downloadContentTexts?.pausedContentText
+                        ?: ""
                 )
             )
         }
@@ -219,7 +235,20 @@ internal class DownloadManager(
                     tag = downloadEntity.tag,
                     id = downloadEntity.id,
                     headers = WorkUtil.jsonToHashMap(downloadEntity.headersJson),
-                    metaData = downloadEntity.metaData
+                    metaData = downloadEntity.metaData,
+                    downloadTitles = DownloadTitles(
+                        progressTitle = downloadEntity.progressTitle,
+                        successTitle = downloadEntity.successTitle,
+                        failedTitle = downloadEntity.failedTitle,
+                        canceledTitle = downloadEntity.canceledTitle,
+                        pausedTitle = downloadEntity.pausedTitle
+                    ),
+                    downloadContentTexts = DownloadContentTexts(
+                        successContentText = downloadEntity.successContentText,
+                        failedContentText = downloadEntity.failedContentText,
+                        canceledContentText = downloadEntity.canceledContentText,
+                        pausedContentText = downloadEntity.pausedContentText
+                    )
                 )
             )
         }
@@ -246,6 +275,7 @@ internal class DownloadManager(
                 DownloadNotificationManager(
                     context = context,
                     notificationConfig = notificationConfig,
+                    buttonTextConfig = buttonTextConfig,
                     requestId = id,
                     fileName = downloadEntity.fileName,
                     downloadTitles = DownloadTitles(
@@ -255,6 +285,12 @@ internal class DownloadManager(
                         canceledTitle = downloadEntity.canceledTitle,
                         pausedTitle = downloadEntity.pausedTitle,
                     ),
+                    downloadContentTexts = DownloadContentTexts(
+                        failedContentText = downloadEntity.failedContentText,
+                        successContentText = downloadEntity.successContentText,
+                        canceledContentText = downloadEntity.canceledContentText,
+                        pausedContentText = downloadEntity.pausedContentText
+                    )
                 ).sendDownloadCancelledNotification()
             }
         }
@@ -291,7 +327,20 @@ internal class DownloadManager(
                     tag = downloadEntity.tag,
                     id = downloadEntity.id,
                     headers = WorkUtil.jsonToHashMap(downloadEntity.headersJson),
-                    metaData = downloadEntity.metaData
+                    metaData = downloadEntity.metaData,
+                    downloadTitles = DownloadTitles(
+                        progressTitle = downloadEntity.progressTitle,
+                        failedTitle = downloadEntity.failedTitle,
+                        successTitle = downloadEntity.successTitle,
+                        canceledTitle = downloadEntity.canceledTitle,
+                        pausedTitle = downloadEntity.pausedTitle,
+                    ),
+                    downloadContentTexts = DownloadContentTexts(
+                        failedContentText = downloadEntity.failedContentText,
+                        successContentText = downloadEntity.successContentText,
+                        canceledContentText = downloadEntity.canceledContentText,
+                        pausedContentText = downloadEntity.pausedContentText
+                    )
                 )
             )
         }

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadManager.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadManager.kt
@@ -196,29 +196,8 @@ internal class DownloadManager(
                     lastModified = System.currentTimeMillis(),
                     userAction = UserAction.START.toString(),
                     metaData = downloadRequest.metaData,
-                    progressTitle = downloadRequest.downloadTitles?.progressTitle ?: "",
-                    failedTitle = downloadRequest.downloadTitles?.failedTitle ?: "",
-                    successTitle = downloadRequest.downloadTitles?.successTitle ?: "",
-                    canceledTitle = downloadRequest.downloadTitles?.canceledTitle ?: "",
-                    pausedTitle = downloadRequest.downloadTitles?.pausedTitle ?: "",
-                    failedContentText = downloadRequest.downloadContentTexts?.failedContentText
-                        ?: "",
-                    successContentText = downloadRequest.downloadContentTexts?.successContentText
-                        ?: "",
-                    canceledContentText = downloadRequest.downloadContentTexts?.canceledContentText
-                        ?: "",
-                    pausedContentText = downloadRequest.downloadContentTexts?.pausedContentText
-                        ?: "",
-                    progressContentTextOnlySeconds = downloadRequest.downloadContentTexts?.progressContentText?.onlySeconds
-                        ?: "",
-                    progressContentTextOnlyMinutes = downloadRequest.downloadContentTexts?.progressContentText?.onlySeconds
-                        ?: "",
-                    progressContentTextOnlyHours = downloadRequest.downloadContentTexts?.progressContentText?.onlyMinutes
-                        ?: "",
-                    progressContentTextMinutesAndSeconds = downloadRequest.downloadContentTexts?.progressContentText?.minutesAndSeconds
-                        ?: "",
-                    progressContentTextHoursAndMinutes = downloadRequest.downloadContentTexts?.progressContentText?.hoursAndMinutes
-                        ?: ""
+                    downloadTitles = downloadRequest.downloadTitles?.toJson() ?: "",
+                    downloadContentTexts = downloadRequest.downloadContentTexts?.toJson() ?: ""
                 )
             )
         }
@@ -248,26 +227,8 @@ internal class DownloadManager(
                     id = downloadEntity.id,
                     headers = WorkUtil.jsonToHashMap(downloadEntity.headersJson),
                     metaData = downloadEntity.metaData,
-                    downloadTitles = DownloadTitles(
-                        progressTitle = downloadEntity.progressTitle,
-                        successTitle = downloadEntity.successTitle,
-                        failedTitle = downloadEntity.failedTitle,
-                        canceledTitle = downloadEntity.canceledTitle,
-                        pausedTitle = downloadEntity.pausedTitle
-                    ),
-                    downloadContentTexts = DownloadContentTexts(
-                        successContentText = downloadEntity.successContentText,
-                        failedContentText = downloadEntity.failedContentText,
-                        canceledContentText = downloadEntity.canceledContentText,
-                        pausedContentText = downloadEntity.pausedContentText,
-                        progressContentText = DownloadProgressContentText(
-                            onlySeconds = downloadEntity.progressContentTextOnlySeconds,
-                            onlyMinutes = downloadEntity.progressContentTextOnlyMinutes,
-                            onlyHours = downloadEntity.progressContentTextOnlyHours,
-                            minutesAndSeconds = downloadEntity.progressContentTextMinutesAndSeconds,
-                            hoursAndMinutes = downloadEntity.progressContentTextHoursAndMinutes
-                        )
-                    )
+                    downloadTitles = WorkUtil.jsonToDownloadTitles(downloadEntity.downloadTitles),
+                    downloadContentTexts = WorkUtil.jsonToDownloadContentTexts(downloadEntity.downloadContentTexts)
                 )
             )
         }
@@ -297,26 +258,8 @@ internal class DownloadManager(
                     buttonTextConfig = buttonTextConfig,
                     requestId = id,
                     fileName = downloadEntity.fileName,
-                    downloadTitles = DownloadTitles(
-                        progressTitle = downloadEntity.progressTitle,
-                        failedTitle = downloadEntity.failedTitle,
-                        successTitle = downloadEntity.successTitle,
-                        canceledTitle = downloadEntity.canceledTitle,
-                        pausedTitle = downloadEntity.pausedTitle,
-                    ),
-                    downloadContentTexts = DownloadContentTexts(
-                        failedContentText = downloadEntity.failedContentText,
-                        successContentText = downloadEntity.successContentText,
-                        canceledContentText = downloadEntity.canceledContentText,
-                        pausedContentText = downloadEntity.pausedContentText,
-                        progressContentText = DownloadProgressContentText(
-                            onlySeconds = downloadEntity.progressContentTextOnlySeconds,
-                            onlyMinutes = downloadEntity.progressContentTextOnlyMinutes,
-                            onlyHours = downloadEntity.progressContentTextOnlyHours,
-                            minutesAndSeconds = downloadEntity.progressContentTextMinutesAndSeconds,
-                            hoursAndMinutes = downloadEntity.progressContentTextHoursAndMinutes
-                        )
-                    )
+                    downloadTitles = WorkUtil.jsonToDownloadTitles(downloadEntity.downloadTitles),
+                    downloadContentTexts = WorkUtil.jsonToDownloadContentTexts(downloadEntity.downloadContentTexts)
                 ).sendDownloadCancelledNotification()
             }
         }
@@ -354,26 +297,8 @@ internal class DownloadManager(
                     id = downloadEntity.id,
                     headers = WorkUtil.jsonToHashMap(downloadEntity.headersJson),
                     metaData = downloadEntity.metaData,
-                    downloadTitles = DownloadTitles(
-                        progressTitle = downloadEntity.progressTitle,
-                        failedTitle = downloadEntity.failedTitle,
-                        successTitle = downloadEntity.successTitle,
-                        canceledTitle = downloadEntity.canceledTitle,
-                        pausedTitle = downloadEntity.pausedTitle,
-                    ),
-                    downloadContentTexts = DownloadContentTexts(
-                        failedContentText = downloadEntity.failedContentText,
-                        successContentText = downloadEntity.successContentText,
-                        canceledContentText = downloadEntity.canceledContentText,
-                        pausedContentText = downloadEntity.pausedContentText,
-                        progressContentText = DownloadProgressContentText(
-                            onlySeconds = downloadEntity.progressContentTextOnlySeconds,
-                            onlyMinutes = downloadEntity.progressContentTextOnlyMinutes,
-                            onlyHours = downloadEntity.progressContentTextOnlyHours,
-                            minutesAndSeconds = downloadEntity.progressContentTextMinutesAndSeconds,
-                            hoursAndMinutes = downloadEntity.progressContentTextHoursAndMinutes
-                        )
-                    )
+                    downloadTitles = WorkUtil.jsonToDownloadTitles(downloadEntity.downloadTitles),
+                    downloadContentTexts = WorkUtil.jsonToDownloadContentTexts(downloadEntity.downloadContentTexts)
                 )
             )
         }

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadManager.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadManager.kt
@@ -85,11 +85,13 @@ internal class DownloadManager(
                                             msg = "Download in Progress. FileName: ${downloadEntity?.fileName}, " +
                                                     "ID: ${downloadEntity?.id}, " +
                                                     "Size in bytes: ${downloadEntity?.totalBytes}, " +
-                                                    "downloadPercent: ${if (downloadEntity != null && downloadEntity.totalBytes.toInt() != 0) {
-                                                        ((downloadEntity.downloadedBytes * 100) / downloadEntity.totalBytes).toInt()
-                                                    } else {
-                                                        0
-                                                    }}%, " +
+                                                    "downloadPercent: ${
+                                                        if (downloadEntity != null && downloadEntity.totalBytes.toInt() != 0) {
+                                                            ((downloadEntity.downloadedBytes * 100) / downloadEntity.totalBytes).toInt()
+                                                        } else {
+                                                            0
+                                                        }
+                                                    }%, " +
                                                     "downloadSpeedInBytesPerMilliSeconds: ${downloadEntity?.speedInBytePerMs} b/ms"
                                         )
 
@@ -206,6 +208,16 @@ internal class DownloadManager(
                     canceledContentText = downloadRequest.downloadContentTexts?.canceledContentText
                         ?: "",
                     pausedContentText = downloadRequest.downloadContentTexts?.pausedContentText
+                        ?: "",
+                    progressContentTextOnlySeconds = downloadRequest.downloadContentTexts?.progressContentText?.onlySeconds
+                        ?: "",
+                    progressContentTextOnlyMinutes = downloadRequest.downloadContentTexts?.progressContentText?.onlySeconds
+                        ?: "",
+                    progressContentTextOnlyHours = downloadRequest.downloadContentTexts?.progressContentText?.onlyMinutes
+                        ?: "",
+                    progressContentTextMinutesAndSeconds = downloadRequest.downloadContentTexts?.progressContentText?.minutesAndSeconds
+                        ?: "",
+                    progressContentTextHoursAndMinutes = downloadRequest.downloadContentTexts?.progressContentText?.hoursAndMinutes
                         ?: ""
                 )
             )
@@ -247,7 +259,14 @@ internal class DownloadManager(
                         successContentText = downloadEntity.successContentText,
                         failedContentText = downloadEntity.failedContentText,
                         canceledContentText = downloadEntity.canceledContentText,
-                        pausedContentText = downloadEntity.pausedContentText
+                        pausedContentText = downloadEntity.pausedContentText,
+                        progressContentText = DownloadProgressContentText(
+                            onlySeconds = downloadEntity.progressContentTextOnlySeconds,
+                            onlyMinutes = downloadEntity.progressContentTextOnlyMinutes,
+                            onlyHours = downloadEntity.progressContentTextOnlyHours,
+                            minutesAndSeconds = downloadEntity.progressContentTextMinutesAndSeconds,
+                            hoursAndMinutes = downloadEntity.progressContentTextHoursAndMinutes
+                        )
                     )
                 )
             )
@@ -289,7 +308,14 @@ internal class DownloadManager(
                         failedContentText = downloadEntity.failedContentText,
                         successContentText = downloadEntity.successContentText,
                         canceledContentText = downloadEntity.canceledContentText,
-                        pausedContentText = downloadEntity.pausedContentText
+                        pausedContentText = downloadEntity.pausedContentText,
+                        progressContentText = DownloadProgressContentText(
+                            onlySeconds = downloadEntity.progressContentTextOnlySeconds,
+                            onlyMinutes = downloadEntity.progressContentTextOnlyMinutes,
+                            onlyHours = downloadEntity.progressContentTextOnlyHours,
+                            minutesAndSeconds = downloadEntity.progressContentTextMinutesAndSeconds,
+                            hoursAndMinutes = downloadEntity.progressContentTextHoursAndMinutes
+                        )
                     )
                 ).sendDownloadCancelledNotification()
             }
@@ -339,7 +365,14 @@ internal class DownloadManager(
                         failedContentText = downloadEntity.failedContentText,
                         successContentText = downloadEntity.successContentText,
                         canceledContentText = downloadEntity.canceledContentText,
-                        pausedContentText = downloadEntity.pausedContentText
+                        pausedContentText = downloadEntity.pausedContentText,
+                        progressContentText = DownloadProgressContentText(
+                            onlySeconds = downloadEntity.progressContentTextOnlySeconds,
+                            onlyMinutes = downloadEntity.progressContentTextOnlyMinutes,
+                            onlyHours = downloadEntity.progressContentTextOnlyHours,
+                            minutesAndSeconds = downloadEntity.progressContentTextMinutesAndSeconds,
+                            hoursAndMinutes = downloadEntity.progressContentTextHoursAndMinutes
+                        )
                     )
                 )
             )

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadManager.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadManager.kt
@@ -85,13 +85,11 @@ internal class DownloadManager(
                                             msg = "Download in Progress. FileName: ${downloadEntity?.fileName}, " +
                                                     "ID: ${downloadEntity?.id}, " +
                                                     "Size in bytes: ${downloadEntity?.totalBytes}, " +
-                                                    "downloadPercent: ${
-                                                        if (downloadEntity != null && downloadEntity.totalBytes.toInt() != 0) {
-                                                            ((downloadEntity.downloadedBytes * 100) / downloadEntity.totalBytes).toInt()
-                                                        } else {
-                                                            0
-                                                        }
-                                                    }%, " +
+                                                    "downloadPercent: ${if (downloadEntity != null && downloadEntity.totalBytes.toInt() != 0) {
+                                                        ((downloadEntity.downloadedBytes * 100) / downloadEntity.totalBytes).toInt()
+                                                    } else {
+                                                        0
+                                                    }}%, " +
                                                     "downloadSpeedInBytesPerMilliSeconds: ${downloadEntity?.speedInBytePerMs} b/ms"
                                         )
 

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadManager.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadManager.kt
@@ -247,7 +247,14 @@ internal class DownloadManager(
                     context = context,
                     notificationConfig = notificationConfig,
                     requestId = id,
-                    fileName = downloadEntity.fileName
+                    fileName = downloadEntity.fileName,
+                    downloadTitles = DownloadTitles(
+                        progressTitle = downloadEntity.progressTitle,
+                        failedTitle = downloadEntity.failedTitle,
+                        successTitle = downloadEntity.successTitle,
+                        canceledTitle = downloadEntity.canceledTitle,
+                        pausedTitle = downloadEntity.pausedTitle,
+                    ),
                 ).sendDownloadCancelledNotification()
             }
         }

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadRequest.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadRequest.kt
@@ -13,5 +13,6 @@ internal data class DownloadRequest(
     val headers: HashMap<String, String> = hashMapOf(),
     val metaData: String = "",
     val supportPauseResume: Boolean = true,
-    val downloadTitles: DownloadTitles? = null
+    val downloadTitles: DownloadTitles? = null,
+    val downloadContentTexts: DownloadContentTexts? = null
 )

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadRequest.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadRequest.kt
@@ -13,4 +13,5 @@ internal data class DownloadRequest(
     val headers: HashMap<String, String> = hashMapOf(),
     val metaData: String = "",
     val supportPauseResume: Boolean = true,
+    val downloadTitles: DownloadTitles? = null
 )

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadTitles.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadTitles.kt
@@ -13,9 +13,18 @@ data class DownloadTitles(
 
 @Serializable
 data class DownloadContentTexts(
-    var progressContentText: String? = null,
+    var progressContentText: DownloadProgressContentText? = null,
     val failedContentText: String? = null,
     val successContentText: String? = null,
     val canceledContentText: String? = null,
     val pausedContentText: String? = null,
+)
+
+@Serializable
+data class DownloadProgressContentText(
+    val onlySeconds: String,
+    val onlyMinutes: String,
+    val onlyHours: String,
+    val minutesAndSeconds: String,
+    val hoursAndMinutes: String
 )

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadTitles.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadTitles.kt
@@ -4,10 +4,18 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class DownloadTitles(
-    var startTitle: String? = null,
     var progressTitle: String? = null,
     val failedTitle: String? = null,
     val successTitle: String? = null,
     val canceledTitle: String? = null,
     val pausedTitle: String? = null,
+)
+
+@Serializable
+data class DownloadContentTexts(
+    var progressContentText: String? = null,
+    val failedContentText: String? = null,
+    val successContentText: String? = null,
+    val canceledContentText: String? = null,
+    val pausedContentText: String? = null,
 )

--- a/ketch/src/main/java/com/ketch/internal/download/DownloadTitles.kt
+++ b/ketch/src/main/java/com/ketch/internal/download/DownloadTitles.kt
@@ -1,0 +1,13 @@
+package com.ketch.internal.download
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DownloadTitles(
+    var startTitle: String? = null,
+    var progressTitle: String? = null,
+    val failedTitle: String? = null,
+    val successTitle: String? = null,
+    val canceledTitle: String? = null,
+    val pausedTitle: String? = null,
+)

--- a/ketch/src/main/java/com/ketch/internal/notification/DownloadNotificationManager.kt
+++ b/ketch/src/main/java/com/ketch/internal/notification/DownloadNotificationManager.kt
@@ -184,6 +184,10 @@ internal class DownloadNotificationManager(
         progress: Int,
         length: Long
     ): String {
+        downloadContentTexts?.progressContentText?.let {
+            return TextUtil.getTextFromCustomTemplate(speedInBPerMs, progress, length, it)
+        }
+
         val timeLeftText = TextUtil.getTimeLeftText(speedInBPerMs, progress, length)
         val speedText = TextUtil.getSpeedText(speedInBPerMs)
         val lengthText = TextUtil.getTotalLengthText(length)

--- a/ketch/src/main/java/com/ketch/internal/notification/DownloadNotificationManager.kt
+++ b/ketch/src/main/java/com/ketch/internal/notification/DownloadNotificationManager.kt
@@ -11,7 +11,9 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.work.ForegroundInfo
+import com.ketch.ButtonTextConfig
 import com.ketch.NotificationConfig
+import com.ketch.internal.download.DownloadContentTexts
 import com.ketch.internal.download.DownloadTitles
 import com.ketch.internal.utils.DownloadConst
 import com.ketch.internal.utils.NotificationConst
@@ -34,9 +36,11 @@ import com.ketch.internal.utils.WorkUtil.removeNotification
 internal class DownloadNotificationManager(
     private val context: Context,
     private val notificationConfig: NotificationConfig,
+    private val buttonTextConfig: ButtonTextConfig,
     private val requestId: Int,
     private val fileName: String,
-    private val downloadTitles: DownloadTitles?
+    private val downloadTitles: DownloadTitles?,
+    private val downloadContentTexts: DownloadContentTexts?
 ) {
 
     private var foregroundInfo: ForegroundInfo? = null
@@ -149,12 +153,12 @@ internal class DownloadNotificationManager(
                 .setOngoing(true)
 
             if (length != 0L) {
-                nb = nb.addAction(-1, NotificationConst.PAUSE_BUTTON_TEXT, pendingIntentPause)
+                nb = nb.addAction(-1, buttonTextConfig.pause, pendingIntentPause)
             }
 
             foregroundInfo = ForegroundInfo(
                 notificationId,
-                nb.addAction(-1, NotificationConst.CANCEL_BUTTON_TEXT, pendingIntentCancel)
+                nb.addAction(-1, buttonTextConfig.cancel, pendingIntentCancel)
                     .setDeleteIntent(pendingIntentDismiss)
                     .build(),
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -225,7 +229,12 @@ internal class DownloadNotificationManager(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
                     notificationConfig.smallIcon
                 )
+                putExtra(NotificationConst.CANCEL_BUTTON_TEXT, buttonTextConfig.cancel)
+                putExtra(NotificationConst.PAUSE_BUTTON_TEXT, buttonTextConfig.pause)
+                putExtra(NotificationConst.RESUME_BUTTON_TEXT, buttonTextConfig.resume)
+                putExtra(NotificationConst.RETRY_BUTTON_TEXT, buttonTextConfig.retry)
                 putExtra(DownloadConst.KEY_FILE_NAME, downloadTitles?.successTitle ?: fileName)
+                putExtra(DownloadConst.KEY_CONTENT_TEXT, downloadContentTexts?.successContentText)
                 putExtra(DownloadConst.KEY_LENGTH, totalLength)
                 putExtra(DownloadConst.KEY_REQUEST_ID, requestId)
                 putExtra(NotificationConst.KEY_NOTIFICATION_ID, notificationId)
@@ -258,7 +267,13 @@ internal class DownloadNotificationManager(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
                     notificationConfig.smallIcon
                 )
+
+                putExtra(NotificationConst.CANCEL_BUTTON_TEXT, buttonTextConfig.cancel)
+                putExtra(NotificationConst.PAUSE_BUTTON_TEXT, buttonTextConfig.pause)
+                putExtra(NotificationConst.RESUME_BUTTON_TEXT, buttonTextConfig.resume)
+                putExtra(NotificationConst.RETRY_BUTTON_TEXT, buttonTextConfig.retry)
                 putExtra(DownloadConst.KEY_FILE_NAME, downloadTitles?.failedTitle ?: fileName)
+                putExtra(DownloadConst.KEY_CONTENT_TEXT, downloadContentTexts?.failedContentText)
                 putExtra(DownloadConst.KEY_REQUEST_ID, requestId)
                 putExtra(NotificationConst.KEY_NOTIFICATION_ID, notificationId)
                 putExtra(DownloadConst.KEY_PROGRESS, currentProgress)
@@ -290,7 +305,12 @@ internal class DownloadNotificationManager(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
                     notificationConfig.smallIcon
                 )
+                putExtra(NotificationConst.CANCEL_BUTTON_TEXT, buttonTextConfig.cancel)
+                putExtra(NotificationConst.PAUSE_BUTTON_TEXT, buttonTextConfig.pause)
+                putExtra(NotificationConst.RESUME_BUTTON_TEXT, buttonTextConfig.resume)
+                putExtra(NotificationConst.RETRY_BUTTON_TEXT, buttonTextConfig.retry)
                 putExtra(DownloadConst.KEY_FILE_NAME, downloadTitles?.canceledTitle ?: fileName)
+                putExtra(DownloadConst.KEY_CONTENT_TEXT, downloadContentTexts?.canceledContentText)
                 putExtra(DownloadConst.KEY_REQUEST_ID, requestId)
                 putExtra(NotificationConst.KEY_NOTIFICATION_ID, notificationId)
                 action = NotificationConst.ACTION_DOWNLOAD_CANCELLED
@@ -322,7 +342,12 @@ internal class DownloadNotificationManager(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
                     notificationConfig.smallIcon
                 )
+                putExtra(NotificationConst.CANCEL_BUTTON_TEXT, buttonTextConfig.cancel)
+                putExtra(NotificationConst.PAUSE_BUTTON_TEXT, buttonTextConfig.pause)
+                putExtra(NotificationConst.RESUME_BUTTON_TEXT, buttonTextConfig.resume)
+                putExtra(NotificationConst.RETRY_BUTTON_TEXT, buttonTextConfig.retry)
                 putExtra(DownloadConst.KEY_FILE_NAME, downloadTitles?.pausedTitle ?: fileName)
+                putExtra(DownloadConst.KEY_CONTENT_TEXT, downloadContentTexts?.pausedContentText)
                 putExtra(DownloadConst.KEY_PROGRESS, currentProgress)
                 putExtra(DownloadConst.KEY_REQUEST_ID, requestId)
                 putExtra(NotificationConst.KEY_NOTIFICATION_ID, notificationId)

--- a/ketch/src/main/java/com/ketch/internal/notification/DownloadNotificationManager.kt
+++ b/ketch/src/main/java/com/ketch/internal/notification/DownloadNotificationManager.kt
@@ -12,6 +12,7 @@ import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.work.ForegroundInfo
 import com.ketch.NotificationConfig
+import com.ketch.internal.download.DownloadTitles
 import com.ketch.internal.utils.DownloadConst
 import com.ketch.internal.utils.NotificationConst
 import com.ketch.internal.utils.TextUtil
@@ -34,7 +35,8 @@ internal class DownloadNotificationManager(
     private val context: Context,
     private val notificationConfig: NotificationConfig,
     private val requestId: Int,
-    private val fileName: String
+    private val fileName: String,
+    private val downloadTitles: DownloadTitles?
 ) {
 
     private var foregroundInfo: ForegroundInfo? = null
@@ -140,7 +142,7 @@ internal class DownloadNotificationManager(
 
             var nb = notificationBuilder
                 .setSmallIcon(notificationConfig.smallIcon)
-                .setContentTitle("Downloading $fileName")
+                .setContentTitle(downloadTitles?.progressTitle ?: "Downloading $fileName")
                 .setContentIntent(pendingIntentOpen)
                 .setProgress(DownloadConst.MAX_VALUE_PROGRESS, progress, if (length == 0L) true else false)
                 .setOnlyAlertOnce(true)
@@ -223,7 +225,7 @@ internal class DownloadNotificationManager(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
                     notificationConfig.smallIcon
                 )
-                putExtra(DownloadConst.KEY_FILE_NAME, fileName)
+                putExtra(DownloadConst.KEY_FILE_NAME, downloadTitles?.successTitle ?: fileName)
                 putExtra(DownloadConst.KEY_LENGTH, totalLength)
                 putExtra(DownloadConst.KEY_REQUEST_ID, requestId)
                 putExtra(NotificationConst.KEY_NOTIFICATION_ID, notificationId)
@@ -256,7 +258,7 @@ internal class DownloadNotificationManager(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
                     notificationConfig.smallIcon
                 )
-                putExtra(DownloadConst.KEY_FILE_NAME, fileName)
+                putExtra(DownloadConst.KEY_FILE_NAME, downloadTitles?.failedTitle ?: fileName)
                 putExtra(DownloadConst.KEY_REQUEST_ID, requestId)
                 putExtra(NotificationConst.KEY_NOTIFICATION_ID, notificationId)
                 putExtra(DownloadConst.KEY_PROGRESS, currentProgress)
@@ -288,7 +290,7 @@ internal class DownloadNotificationManager(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
                     notificationConfig.smallIcon
                 )
-                putExtra(DownloadConst.KEY_FILE_NAME, fileName)
+                putExtra(DownloadConst.KEY_FILE_NAME, downloadTitles?.canceledTitle ?: fileName)
                 putExtra(DownloadConst.KEY_REQUEST_ID, requestId)
                 putExtra(NotificationConst.KEY_NOTIFICATION_ID, notificationId)
                 action = NotificationConst.ACTION_DOWNLOAD_CANCELLED
@@ -320,7 +322,7 @@ internal class DownloadNotificationManager(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
                     notificationConfig.smallIcon
                 )
-                putExtra(DownloadConst.KEY_FILE_NAME, fileName)
+                putExtra(DownloadConst.KEY_FILE_NAME, downloadTitles?.pausedTitle ?: fileName)
                 putExtra(DownloadConst.KEY_PROGRESS, currentProgress)
                 putExtra(DownloadConst.KEY_REQUEST_ID, requestId)
                 putExtra(NotificationConst.KEY_NOTIFICATION_ID, notificationId)

--- a/ketch/src/main/java/com/ketch/internal/notification/DownloadNotificationManager.kt
+++ b/ketch/src/main/java/com/ketch/internal/notification/DownloadNotificationManager.kt
@@ -145,7 +145,7 @@ internal class DownloadNotificationManager(
             )
 
             var nb = notificationBuilder
-                .setSmallIcon(notificationConfig.smallIcon)
+                .setSmallIcon(notificationConfig.smallIcons.progress)
                 .setContentTitle(downloadTitles?.progressTitle ?: "Downloading $fileName")
                 .setContentIntent(pendingIntentOpen)
                 .setProgress(DownloadConst.MAX_VALUE_PROGRESS, progress, if (length == 0L) true else false)
@@ -227,7 +227,7 @@ internal class DownloadNotificationManager(
                 )
                 putExtra(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
-                    notificationConfig.smallIcon
+                    notificationConfig.smallIcons.success
                 )
                 putExtra(NotificationConst.CANCEL_BUTTON_TEXT, buttonTextConfig.cancel)
                 putExtra(NotificationConst.PAUSE_BUTTON_TEXT, buttonTextConfig.pause)
@@ -267,7 +267,10 @@ internal class DownloadNotificationManager(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
                     notificationConfig.smallIcon
                 )
-
+                putExtra(
+                    NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
+                    notificationConfig.smallIcons.failed
+                )
                 putExtra(NotificationConst.CANCEL_BUTTON_TEXT, buttonTextConfig.cancel)
                 putExtra(NotificationConst.PAUSE_BUTTON_TEXT, buttonTextConfig.pause)
                 putExtra(NotificationConst.RESUME_BUTTON_TEXT, buttonTextConfig.resume)
@@ -303,7 +306,7 @@ internal class DownloadNotificationManager(
                 )
                 putExtra(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
-                    notificationConfig.smallIcon
+                    notificationConfig.smallIcons.cancelled
                 )
                 putExtra(NotificationConst.CANCEL_BUTTON_TEXT, buttonTextConfig.cancel)
                 putExtra(NotificationConst.PAUSE_BUTTON_TEXT, buttonTextConfig.pause)
@@ -340,7 +343,7 @@ internal class DownloadNotificationManager(
                 )
                 putExtra(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
-                    notificationConfig.smallIcon
+                    notificationConfig.smallIcons.paused
                 )
                 putExtra(NotificationConst.CANCEL_BUTTON_TEXT, buttonTextConfig.cancel)
                 putExtra(NotificationConst.PAUSE_BUTTON_TEXT, buttonTextConfig.pause)

--- a/ketch/src/main/java/com/ketch/internal/notification/DownloadNotificationManager.kt
+++ b/ketch/src/main/java/com/ketch/internal/notification/DownloadNotificationManager.kt
@@ -265,10 +265,6 @@ internal class DownloadNotificationManager(
                 )
                 putExtra(
                     NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
-                    notificationConfig.smallIcon
-                )
-                putExtra(
-                    NotificationConst.KEY_NOTIFICATION_SMALL_ICON,
                     notificationConfig.smallIcons.failed
                 )
                 putExtra(NotificationConst.CANCEL_BUTTON_TEXT, buttonTextConfig.cancel)

--- a/ketch/src/main/java/com/ketch/internal/notification/NotificationReceiver.kt
+++ b/ketch/src/main/java/com/ketch/internal/notification/NotificationReceiver.kt
@@ -102,7 +102,12 @@ internal class NotificationReceiver : BroadcastReceiver() {
                 intent.extras?.getInt(NotificationConst.KEY_NOTIFICATION_SMALL_ICON)
                     ?: NotificationConst.DEFAULT_VALUE_NOTIFICATION_SMALL_ICON
             val fileName = intent.extras?.getString(DownloadConst.KEY_FILE_NAME) ?: ""
+            val contentText = intent.extras?.getString(DownloadConst.KEY_CONTENT_TEXT) ?: ""
             val currentProgress = intent.extras?.getInt(DownloadConst.KEY_PROGRESS) ?: 0
+            val cancelButtonText = intent.extras?.getString(NotificationConst.CANCEL_BUTTON_TEXT)
+            val pauseButtonText = intent.extras?.getString(NotificationConst.PAUSE_BUTTON_TEXT)
+            val resumeButtonText = intent.extras?.getString(NotificationConst.RESUME_BUTTON_TEXT)
+            val retryButtonText = intent.extras?.getString(NotificationConst.RETRY_BUTTON_TEXT)
             val requestId =
                 intent.extras?.getInt(DownloadConst.KEY_REQUEST_ID) ?: -1
             val totalLength = intent.extras?.getLong(DownloadConst.KEY_LENGTH)
@@ -175,17 +180,19 @@ internal class NotificationReceiver : BroadcastReceiver() {
                 NotificationCompat.Builder(context, NotificationConst.NOTIFICATION_CHANNEL_ID)
                     .setSmallIcon(notificationSmallIcon)
                     .setContentText(
-                        when (intent.action) {
-                            NotificationConst.ACTION_DOWNLOAD_COMPLETED ->
-                                "Download successful. (${
-                                    TextUtil.getTotalLengthText(
-                                        totalLength
-                                    )
-                                })"
+                        contentText.ifEmpty {
+                            when (intent.action) {
+                                NotificationConst.ACTION_DOWNLOAD_COMPLETED ->
+                                    "Download successful. (${
+                                        TextUtil.getTotalLengthText(
+                                            totalLength
+                                        )
+                                    })"
 
-                            NotificationConst.ACTION_DOWNLOAD_FAILED -> "Download failed."
-                            NotificationConst.ACTION_DOWNLOAD_PAUSED -> "Download paused."
-                            else -> "Download cancelled."
+                                NotificationConst.ACTION_DOWNLOAD_FAILED -> "Download failed."
+                                NotificationConst.ACTION_DOWNLOAD_PAUSED -> "Download paused."
+                                else -> "Download cancelled."
+                            }
                         }
                     )
                     .setContentTitle(fileName)
@@ -198,22 +205,22 @@ internal class NotificationReceiver : BroadcastReceiver() {
             if (intent.action == NotificationConst.ACTION_DOWNLOAD_FAILED) {
                 notificationBuilder = notificationBuilder.addAction(
                     -1,
-                    NotificationConst.RETRY_BUTTON_TEXT,
+                    retryButtonText,
                     pendingIntentRetry
                 )
                     .setProgress(DownloadConst.MAX_VALUE_PROGRESS, currentProgress, false)
-                    .addAction(-1, NotificationConst.CANCEL_BUTTON_TEXT, pendingIntentCancel)
+                    .addAction(-1, cancelButtonText, pendingIntentCancel)
                     .setSubText("$currentProgress%")
             }
             // add resume and cancel button for paused download
             if (intent.action == NotificationConst.ACTION_DOWNLOAD_PAUSED) {
                 notificationBuilder = notificationBuilder.addAction(
                     -1,
-                    NotificationConst.RESUME_BUTTON_TEXT,
+                    resumeButtonText,
                     pendingIntentResume
                 )
                     .setProgress(DownloadConst.MAX_VALUE_PROGRESS, currentProgress, false)
-                    .addAction(-1, NotificationConst.CANCEL_BUTTON_TEXT, pendingIntentCancel)
+                    .addAction(-1, cancelButtonText, pendingIntentCancel)
                     .setSubText("$currentProgress%")
             }
 

--- a/ketch/src/main/java/com/ketch/internal/utils/DownloadConst.kt
+++ b/ketch/src/main/java/com/ketch/internal/utils/DownloadConst.kt
@@ -8,6 +8,7 @@ internal object DownloadConst {
     const val KEY_FILE_NAME = "key_fileName"
     const val KEY_STATE = "key_state"
     const val KEY_PROGRESS = "key_progress"
+    const val KEY_CONTENT_TEXT = "key_content_text"
     const val MAX_VALUE_PROGRESS = 100
     const val PROGRESS = "progress"
     const val STARTED = "started"
@@ -16,6 +17,7 @@ internal object DownloadConst {
     const val KEY_REQUEST_ID = "key_request_id"
     const val KEY_DOWNLOAD_REQUEST = "key_download_request"
     const val KEY_NOTIFICATION_CONFIG = "key_notification_config"
+    const val KEY_BUTTON_TEXT_CONFIG = "key_button_text_config"
     const val ETAG_HEADER = "ETag"
     const val CONTENT_LENGTH = "Content-Length"
     const val RANGE_HEADER = "Range"

--- a/ketch/src/main/java/com/ketch/internal/utils/TextUtil.kt
+++ b/ketch/src/main/java/com/ketch/internal/utils/TextUtil.kt
@@ -1,5 +1,7 @@
 package com.ketch.internal.utils
 
+import com.ketch.internal.download.DownloadProgressContentText
+
 internal object TextUtil {
 
     private const val MAX_PERCENT = 100
@@ -52,6 +54,72 @@ internal object TextUtil {
         }
 
         return "%.2f %s".format(value, units[unitIndex])
+    }
+
+    fun getTextFromCustomTemplate(
+        speedInBPerMs: Float,
+        progressPercent: Int,
+        lengthInBytes: Long,
+        template: DownloadProgressContentText
+    ): String {
+        val total = getTotalLengthText(lengthInBytes)
+        val speedText = getSpeedText(speedInBPerMs)
+        if (speedInBPerMs == 0F) return ""
+        val speedInBPerSecond = speedInBPerMs * SEC_IN_MILLIS
+        val bytesLeft = (lengthInBytes * (MAX_PERCENT - progressPercent) / MAX_PERCENT).toFloat()
+
+        val secondsLeft = bytesLeft / speedInBPerSecond
+        val minutesLeft = secondsLeft / VALUE_60
+        val hoursLeft = minutesLeft / VALUE_60
+
+        val values = mutableMapOf<String, Any>()
+        values["total"] = total
+        values["speed"] = speedText
+
+        return when {
+            secondsLeft < VALUE_60 -> {
+                values["second"] = secondsLeft
+                formatPluralTemplate(template.onlySeconds, values)
+            }
+
+            minutesLeft < VALUE_3 -> {
+                values["minute"] = minutesLeft
+                values["second"] = secondsLeft % VALUE_60
+                formatPluralTemplate(template.minutesAndSeconds, values)
+            }
+
+            minutesLeft < VALUE_60 -> {
+                values["minute"] = minutesLeft
+                formatPluralTemplate(template.onlyMinutes, values)
+            }
+
+            minutesLeft < VALUE_300 -> {
+                values["hour"] = hoursLeft
+                values["minute"] = minutesLeft % VALUE_60
+                formatPluralTemplate(template.hoursAndMinutes, values)
+            }
+
+            else -> {
+                values["hour"] = hoursLeft
+                formatPluralTemplate(template.onlyHours, values)
+            }
+        }
+
+    }
+
+    private fun formatPluralTemplate(template: String, values: Map<String, Any>): String {
+        return template.replace(Regex("\\[\\[#(\\w+)\\|([^|]+)\\|([^|]+)]]")) { matchResult ->
+            val key = matchResult.groupValues[1]
+            val singular = matchResult.groupValues[2]
+            val plural = matchResult.groupValues[3]
+
+
+            val value = if (listOf("hour", "minute", "second").contains(key)) {
+                if (values[key].toString().isNotEmpty()) "%.0f".format(values[key]) else 0
+            } else values[key].toString()
+
+            if (value == "1") singular.format(value) else plural.format(value)
+        }.trim()
     }
 
 }

--- a/ketch/src/main/java/com/ketch/internal/utils/TextUtil.kt
+++ b/ketch/src/main/java/com/ketch/internal/utils/TextUtil.kt
@@ -30,7 +30,7 @@ internal object TextUtil {
 
     fun getSpeedText(speedInBPerMs: Float): String {
         var value = speedInBPerMs * SEC_IN_MILLIS
-        val units = arrayOf("b/s", "kb/s", "mb/s", "gb/s")
+        val units = arrayOf("B/s", "KB/s", "MB/s", "GB/s")
         var unitIndex = 0
 
         while (value >= VALUE_500 && unitIndex < units.size - 1) {
@@ -43,7 +43,7 @@ internal object TextUtil {
 
     fun getTotalLengthText(lengthInBytes: Long): String {
         var value = lengthInBytes.toFloat()
-        val units = arrayOf("b", "kb", "mb", "gb")
+        val units = arrayOf("B", "KB", "MB", "GB")
         var unitIndex = 0
 
         while (value >= VALUE_500 && unitIndex < units.size - 1) {

--- a/ketch/src/main/java/com/ketch/internal/utils/WorkUtil.kt
+++ b/ketch/src/main/java/com/ketch/internal/utils/WorkUtil.kt
@@ -2,6 +2,7 @@ package com.ketch.internal.utils
 
 import android.content.Context
 import androidx.core.app.NotificationManagerCompat
+import com.ketch.ButtonTextConfig
 import com.ketch.NotificationConfig
 import com.ketch.internal.download.DownloadRequest
 import kotlinx.serialization.encodeToString
@@ -21,9 +22,20 @@ internal object WorkUtil {
         return Json.encodeToString(this)
     }
 
+    fun ButtonTextConfig.toJson(): String {
+        return Json.encodeToString(this)
+    }
+
     fun jsonToNotificationConfig(jsonStr: String): NotificationConfig {
         if (jsonStr.isEmpty()) {
             return NotificationConfig(smallIcon = NotificationConst.DEFAULT_VALUE_NOTIFICATION_SMALL_ICON)
+        }
+        return Json.decodeFromString(jsonStr)
+    }
+
+    fun jsonToButtonTextConfig(jsonStr: String): ButtonTextConfig {
+        if (jsonStr.isEmpty()) {
+            return ButtonTextConfig()
         }
         return Json.decodeFromString(jsonStr)
     }

--- a/ketch/src/main/java/com/ketch/internal/utils/WorkUtil.kt
+++ b/ketch/src/main/java/com/ketch/internal/utils/WorkUtil.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import androidx.core.app.NotificationManagerCompat
 import com.ketch.ButtonTextConfig
 import com.ketch.NotificationConfig
+import com.ketch.internal.download.DownloadContentTexts
 import com.ketch.internal.download.DownloadRequest
+import com.ketch.internal.download.DownloadTitles
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
@@ -38,6 +40,28 @@ internal object WorkUtil {
             return ButtonTextConfig()
         }
         return Json.decodeFromString(jsonStr)
+    }
+
+    fun jsonToDownloadTitles(jsonStr: String): DownloadTitles {
+        if (jsonStr.isEmpty()) {
+            return DownloadTitles()
+        }
+        return Json.decodeFromString(jsonStr)
+    }
+
+    fun DownloadTitles.toJson(): String {
+        return Json.encodeToString(this)
+    }
+
+    fun jsonToDownloadContentTexts(jsonStr: String): DownloadContentTexts {
+        if (jsonStr.isEmpty()) {
+            return DownloadContentTexts()
+        }
+        return Json.decodeFromString(jsonStr)
+    }
+
+    fun DownloadContentTexts.toJson(): String {
+        return Json.encodeToString(this)
     }
 
     fun hashMapToJson(headers: HashMap<String, String>): String {

--- a/ketch/src/main/java/com/ketch/internal/worker/DownloadWorker.kt
+++ b/ketch/src/main/java/com/ketch/internal/worker/DownloadWorker.kt
@@ -54,13 +54,15 @@ internal class DownloadWorker(
         val fileName = downloadRequest.fileName
         val headers = downloadRequest.headers
         val supportPauseResume = downloadRequest.supportPauseResume // in case of false, we will not store total length info in DB
+        val downloadTitles = downloadRequest.downloadTitles
 
         if (notificationConfig.enabled) {
             downloadNotificationManager = DownloadNotificationManager(
                 context = context,
                 notificationConfig = notificationConfig,
                 requestId = id,
-                fileName = fileName
+                fileName = fileName,
+                downloadTitles = downloadTitles
             )
         }
 

--- a/ketch/src/main/java/com/ketch/internal/worker/DownloadWorker.kt
+++ b/ketch/src/main/java/com/ketch/internal/worker/DownloadWorker.kt
@@ -57,8 +57,7 @@ internal class DownloadWorker(
         val dirPath = downloadRequest.path
         val fileName = downloadRequest.fileName
         val headers = downloadRequest.headers
-        val supportPauseResume =
-            downloadRequest.supportPauseResume // in case of false, we will not store total length info in DB
+        val supportPauseResume = downloadRequest.supportPauseResume // in case of false, we will not store total length info in DB
         val downloadTitles = downloadRequest.downloadTitles
         val downloadContentText = downloadRequest.downloadContentTexts
 

--- a/ketch/src/main/java/com/ketch/internal/worker/DownloadWorker.kt
+++ b/ketch/src/main/java/com/ketch/internal/worker/DownloadWorker.kt
@@ -48,21 +48,29 @@ internal class DownloadWorker(
                 inputData.getString(DownloadConst.KEY_NOTIFICATION_CONFIG) ?: ""
             )
 
+        val buttonTextConfig = WorkUtil.jsonToButtonTextConfig(
+            inputData.getString(DownloadConst.KEY_BUTTON_TEXT_CONFIG) ?: ""
+        )
+
         val id = downloadRequest.id
         val url = downloadRequest.url
         val dirPath = downloadRequest.path
         val fileName = downloadRequest.fileName
         val headers = downloadRequest.headers
-        val supportPauseResume = downloadRequest.supportPauseResume // in case of false, we will not store total length info in DB
+        val supportPauseResume =
+            downloadRequest.supportPauseResume // in case of false, we will not store total length info in DB
         val downloadTitles = downloadRequest.downloadTitles
+        val downloadContentText = downloadRequest.downloadContentTexts
 
         if (notificationConfig.enabled) {
             downloadNotificationManager = DownloadNotificationManager(
                 context = context,
                 notificationConfig = notificationConfig,
+                buttonTextConfig = buttonTextConfig,
                 requestId = id,
                 fileName = fileName,
-                downloadTitles = downloadTitles
+                downloadTitles = downloadTitles,
+                downloadContentTexts = downloadContentText
             )
         }
 


### PR DESCRIPTION
- The changes do not change the original logic at all and are fully compatible (New options are completely optional)
- Added ability to change titles for download statuses (downloading, successful, failed,...), as well as content text. It is also possible to customize how download progress is displayed
- Buttons (Cancel, resume,...) on notifications are customizable (better multilingual support)
- Change the display unit to Megabyte instead of Megabit (original code is calculating Megabyte but is displaying as Megabit)

![Screenshot_2025 03 23_06 19 00](https://github.com/user-attachments/assets/b1bca8aa-2c91-46e1-8833-d1d20d35e0dc) 
